### PR TITLE
Add hero visualizer with Daremon logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,75 @@
     <canvas id="visualizer-canvas"></canvas>
     <div id="offline-indicator" class="hidden" aria-live="assertive" data-i18n-key="offlineMessage"></div>
 
+    <section id="visualizer-showcase" aria-label="Audio visualizer Daremon Solutions">
+        <div class="visualizer-glow" aria-hidden="true">
+            <div class="visualizer-burst"></div>
+            <div class="visualizer-rays"></div>
+        </div>
+        <div class="logo-card" role="img" aria-label="Logo ib In Team Betrouwbaar Daremon Solutions">
+            <div class="logo-header">
+                <span class="logo-ib">i<span>b</span></span>
+                <div class="logo-tagline">
+                    <span class="logo-in">In</span>
+                    <span class="logo-team">Team</span>
+                    <span class="logo-betrouwbaar">Betrouwbaar</span>
+                </div>
+            </div>
+            <div class="logo-emblem" aria-hidden="true">
+                <span class="ring outer"></span>
+                <span class="ring middle"></span>
+                <span class="ring inner"></span>
+                <span class="dot"></span>
+            </div>
+            <div class="logo-wordmark" aria-hidden="true">
+                <span class="wordmark-primary">DAREMON</span>
+                <span class="wordmark-secondary">SOLUTIONS</span>
+            </div>
+        </div>
+        <div class="visualizer-bars" aria-hidden="true">
+            <span class="bar" style="--i:0"></span>
+            <span class="bar" style="--i:1"></span>
+            <span class="bar" style="--i:2"></span>
+            <span class="bar" style="--i:3"></span>
+            <span class="bar" style="--i:4"></span>
+            <span class="bar" style="--i:5"></span>
+            <span class="bar" style="--i:6"></span>
+            <span class="bar" style="--i:7"></span>
+            <span class="bar" style="--i:8"></span>
+            <span class="bar" style="--i:9"></span>
+            <span class="bar" style="--i:10"></span>
+            <span class="bar" style="--i:11"></span>
+            <span class="bar" style="--i:12"></span>
+            <span class="bar" style="--i:13"></span>
+            <span class="bar" style="--i:14"></span>
+            <span class="bar" style="--i:15"></span>
+            <span class="bar" style="--i:16"></span>
+            <span class="bar" style="--i:17"></span>
+            <span class="bar" style="--i:18"></span>
+            <span class="bar" style="--i:19"></span>
+            <span class="bar" style="--i:20"></span>
+            <span class="bar" style="--i:21"></span>
+            <span class="bar" style="--i:22"></span>
+            <span class="bar" style="--i:23"></span>
+            <span class="bar" style="--i:24"></span>
+            <span class="bar" style="--i:25"></span>
+            <span class="bar" style="--i:26"></span>
+            <span class="bar" style="--i:27"></span>
+            <span class="bar" style="--i:28"></span>
+            <span class="bar" style="--i:29"></span>
+            <span class="bar" style="--i:30"></span>
+            <span class="bar" style="--i:31"></span>
+        </div>
+        <figure class="photo-frame hero-left" aria-labelledby="hero-photo-left-caption">
+            <img src="https://placehold.co/220x300/04132B/18A0C7?text=Live+Show" alt="Teamlid presenteert live-uitzending">
+            <figcaption id="hero-photo-left-caption" data-i18n-key="heroPhotoLeftCaption"></figcaption>
+        </figure>
+        <figure class="photo-frame hero-right" aria-labelledby="hero-photo-right-caption">
+            <img src="https://placehold.co/220x300/082552/9BD6FF?text=Studio" alt="Studioverlichting en mengpaneel">
+            <figcaption id="hero-photo-right-caption" data-i18n-key="heroPhotoRightCaption"></figcaption>
+        </figure>
+    </section>
+
     <div id="app-container">
         <!-- Main Radio Player View -->
         <div id="radio-view">
@@ -90,6 +159,24 @@
                             <button id="theme-rave" data-i18n-title="themeRave" data-i18n-aria-label="themeRaveLabel"></button>
                         </div>
                     </section>
+
+                    <section class="content-box photo-gallery" aria-label="Fotogalerij radio">
+                        <h3 data-i18n-key="photoGalleryTitle"></h3>
+                        <div class="photo-gallery-grid">
+                            <figure class="photo-card">
+                                <img src="https://placehold.co/180x180/0B1F3A/18A0C7?text=DJ" alt="DJ achter het mengpaneel" loading="lazy">
+                                <figcaption data-i18n-key="photoGalleryCaptionStudio"></figcaption>
+                            </figure>
+                            <figure class="photo-card">
+                                <img src="https://placehold.co/180x180/04132B/9BD6FF?text=Team" alt="Productieteam lacht in studio" loading="lazy">
+                                <figcaption data-i18n-key="photoGalleryCaptionTeam"></figcaption>
+                            </figure>
+                            <figure class="photo-card">
+                                <img src="https://placehold.co/180x180/082552/18A0C7?text=Live" alt="Luisteraars tijdens live-event" loading="lazy">
+                                <figcaption data-i18n-key="photoGalleryCaptionCommunity"></figcaption>
+                            </figure>
+                        </div>
+                    </section>
                 </div>
             </aside>
 
@@ -132,6 +219,24 @@
                             <input type="range" id="volume-slider" min="0" max="1" step="0.01" value="0.5" data-i18n-aria-label="volumeLabel">
                         </div>
                         <button id="tv-mode-btn" class="control-btn" data-i18n-title="fullscreenTooltip" data-i18n-aria-label="fullscreenLabel" disabled>📺</button>
+                    </div>
+                </section>
+                <section id="team-moments" class="content-box photo-collage" aria-labelledby="team-moments-title">
+                    <h2 id="team-moments-title" data-i18n-key="teamMomentsTitle"></h2>
+                    <p class="section-intro" data-i18n-key="teamMomentsIntro"></p>
+                    <div class="photo-collage-grid">
+                        <figure class="collage-card">
+                            <img src="https://placehold.co/260x160/082552/18A0C7?text=Behind+the+Scenes" alt="Technici stemmen microfoons af" loading="lazy">
+                            <figcaption data-i18n-key="teamMomentsCaptionPrep"></figcaption>
+                        </figure>
+                        <figure class="collage-card">
+                            <img src="https://placehold.co/260x160/04132B/9BD6FF?text=Interview" alt="Interview met speciale gast" loading="lazy">
+                            <figcaption data-i18n-key="teamMomentsCaptionInterview"></figcaption>
+                        </figure>
+                        <figure class="collage-card">
+                            <img src="https://placehold.co/260x160/0B1F3A/18A0C7?text=Community" alt="Luisteraars sturen berichten" loading="lazy">
+                            <figcaption data-i18n-key="teamMomentsCaptionCommunity"></figcaption>
+                        </figure>
                     </div>
                 </section>
                 <div id="hotkeys-info" data-i18n-key="hotkeysInfo"></div>

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -8,7 +8,12 @@
   "retryFailed": "Opnieuw proberen mislukt: {{message}}",
   "you": "Jij",
   "aiDjName": "DJ Bot",
-  "aiResponses": ["Bedankt voor je bericht!", "Leuk dat je luistert!", "Geweldige muziekkeuze!", "Blijf genieten van de muziek!"],
+  "aiResponses": [
+    "Bedankt voor je bericht!",
+    "Leuk dat je luistert!",
+    "Geweldige muziekkeuze!",
+    "Blijf genieten van de muziek!"
+  ],
   "trackTitleDefault": "Welkom bij DAREMON Radio ETS",
   "trackArtistDefault": "Het beste van technologie en muziek",
   "headerSubtitle": "Het officiële bedrijfsradiostation",
@@ -73,5 +78,16 @@
   "cancelBtn": "Annuleren",
   "noScript": "JavaScript is vereist voor deze applicatie. Schakel JavaScript in om door te gaan.",
   "footerDisclaimer": "© 2024 DAREMON Radio ETS - Fictief bedrijfsradiostation voor demonstratiedoeleinden",
-  "footerDisclaimer2": "Alle muziek en inhoud zijn voor educatieve doeleinden. Geen echte uitzending."
+  "footerDisclaimer2": "Alle muziek en inhoud zijn voor educatieve doeleinden. Geen echte uitzending.",
+  "heroPhotoLeftCaption": "Live-uitzending",
+  "heroPhotoRightCaption": "Studiogloed",
+  "photoGalleryTitle": "Fotogalerij",
+  "photoGalleryCaptionStudio": "Aan het mengpaneel",
+  "photoGalleryCaptionTeam": "Team in actie",
+  "photoGalleryCaptionCommunity": "Community live moment",
+  "teamMomentsTitle": "Momenten uit het station",
+  "teamMomentsIntro": "Ontdek de sfeer achter de schermen met snapshots uit het DAREMON Radio ETS-team.",
+  "teamMomentsCaptionPrep": "Voorbereiding achter de schermen",
+  "teamMomentsCaptionInterview": "Interview met speciale gast",
+  "teamMomentsCaptionCommunity": "Community interactie"
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -8,7 +8,12 @@
   "retryFailed": "Ponowna próba nieudana: {{message}}",
   "you": "Ty",
   "aiDjName": "DJ Bot",
-  "aiResponses": ["Dzięki za wiadomość!", "Miło, że słuchasz!", "Świetny wybór muzyki!", "Ciesz się muzyką!"],
+  "aiResponses": [
+    "Dzięki za wiadomość!",
+    "Miło, że słuchasz!",
+    "Świetny wybór muzyki!",
+    "Ciesz się muzyką!"
+  ],
   "trackTitleDefault": "Witamy w DAREMON Radio ETS",
   "trackArtistDefault": "Najlepsze z technologii i muzyki",
   "headerSubtitle": "Oficjalne radio firmowe",
@@ -73,5 +78,16 @@
   "cancelBtn": "Anuluj",
   "noScript": "JavaScript jest wymagany dla tej aplikacji. Włącz JavaScript aby kontynuować.",
   "footerDisclaimer": "© 2024 DAREMON Radio ETS - Fikcyjne radio firmowe do celów demonstracyjnych",
-  "footerDisclaimer2": "Cała muzyka i treści są do celów edukacyjnych. Brak rzeczywistej transmisji."
+  "footerDisclaimer2": "Cała muzyka i treści są do celów edukacyjnych. Brak rzeczywistej transmisji.",
+  "heroPhotoLeftCaption": "Transmisja na żywo",
+  "heroPhotoRightCaption": "Atmosfera studia",
+  "photoGalleryTitle": "Galeria zdjęć",
+  "photoGalleryCaptionStudio": "Przy konsolecie",
+  "photoGalleryCaptionTeam": "Zespół w akcji",
+  "photoGalleryCaptionCommunity": "Społeczność na żywo",
+  "teamMomentsTitle": "Kadry ze stacji",
+  "teamMomentsIntro": "Zobacz kulisy działania DAREMON Radio ETS na wybranych fotografiach.",
+  "teamMomentsCaptionPrep": "Przygotowania za kulisami",
+  "teamMomentsCaptionInterview": "Wywiad ze specjalnym gościem",
+  "teamMomentsCaptionCommunity": "Interakcje ze słuchaczami"
 }

--- a/styles.css
+++ b/styles.css
@@ -71,6 +71,292 @@ body {
     opacity: 0.55;
 }
 
+#visualizer-showcase {
+    position: relative;
+    width: 100%;
+    max-width: 960px;
+    min-height: 520px;
+    margin: 40px auto 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.visualizer-glow {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+}
+
+.visualizer-glow::before {
+    content: "";
+    position: absolute;
+    width: 760px;
+    height: 760px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 164, 0, 0.25) 0%, rgba(4, 19, 43, 0) 65%);
+    filter: blur(4px);
+}
+
+.visualizer-burst {
+    width: 520px;
+    height: 520px;
+    border-radius: 50%;
+    background: conic-gradient(from 0deg, rgba(255, 164, 0, 0.35), rgba(255, 210, 99, 0.05), rgba(255, 164, 0, 0.35));
+    mask: radial-gradient(circle, transparent 0%, transparent 45%, black 46%);
+    animation: burst-rotate 12s linear infinite;
+}
+
+.visualizer-rays {
+    position: absolute;
+    width: 640px;
+    height: 640px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 181, 69, 0.18) 0%, rgba(255, 181, 69, 0) 60%);
+    animation: rays-pulse 6s ease-in-out infinite;
+}
+
+.logo-card {
+    position: relative;
+    z-index: 2;
+    padding: 48px 64px 56px;
+    border-radius: 36px;
+    background: radial-gradient(circle at 30% 20%, rgba(31, 88, 148, 0.55), rgba(4, 19, 43, 0.95));
+    backdrop-filter: blur(14px);
+    box-shadow: 0 32px 80px rgba(4, 19, 43, 0.75), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(24, 160, 199, 0.4);
+}
+
+.logo-header {
+    display: flex;
+    align-items: flex-end;
+    gap: 24px;
+    justify-content: center;
+}
+
+.logo-ib {
+    font-size: clamp(4.5rem, 10vw, 5.4rem);
+    font-weight: 700;
+    letter-spacing: -6px;
+    text-transform: lowercase;
+    color: #d1d5db;
+    text-shadow: 0 0 16px rgba(255, 255, 255, 0.35);
+}
+
+.logo-ib span {
+    display: inline-block;
+    color: #f7f7f7;
+    font-weight: 800;
+    transform: translateX(-10px);
+}
+
+.logo-tagline {
+    display: grid;
+    text-transform: uppercase;
+    font-size: clamp(0.9rem, 2vw, 1.1rem);
+    row-gap: 2px;
+    letter-spacing: 0.28em;
+    text-align: left;
+}
+
+.logo-in {
+    color: #7ee0ff;
+}
+
+.logo-team {
+    color: #7ee0ff;
+    font-weight: 600;
+}
+
+.logo-betrouwbaar {
+    color: #b7d4ff;
+    font-weight: 300;
+    letter-spacing: 0.24em;
+}
+
+.logo-emblem {
+    position: relative;
+    width: 220px;
+    height: 220px;
+    margin: 36px auto 28px;
+}
+
+.logo-emblem .ring {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    border: 6px solid transparent;
+    background: conic-gradient(from 90deg, rgba(0, 174, 239, 0.9), rgba(4, 19, 43, 0.35), rgba(0, 174, 239, 0.9)) border-box;
+    mask: radial-gradient(circle, transparent 63%, black 64%);
+}
+
+.logo-emblem .ring.outer {
+    width: 220px;
+    height: 220px;
+    border-width: 8px;
+}
+
+.logo-emblem .ring.middle {
+    width: 150px;
+    height: 150px;
+    border-width: 10px;
+    mask: radial-gradient(circle, transparent 54%, black 55%);
+}
+
+.logo-emblem .ring.inner {
+    width: 92px;
+    height: 92px;
+    border-width: 12px;
+    mask: radial-gradient(circle, transparent 37%, black 38%);
+}
+
+.logo-emblem .dot {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #7ee0ff, #18a0c7);
+    box-shadow: 0 0 18px rgba(126, 224, 255, 0.8);
+}
+
+.logo-wordmark {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    letter-spacing: 0.35em;
+}
+
+.wordmark-primary {
+    font-size: clamp(1.6rem, 5vw, 2.2rem);
+    font-weight: 800;
+}
+
+.wordmark-secondary {
+    font-size: clamp(0.75rem, 2.5vw, 1rem);
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.75);
+    letter-spacing: 0.48em;
+}
+
+.visualizer-bars {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: flex-end;
+    gap: 6px;
+    padding: 0 24px;
+    height: 180px;
+}
+
+.visualizer-bars::after {
+    content: "";
+    position: absolute;
+    bottom: -24px;
+    left: 0;
+    right: 0;
+    height: 40px;
+    background: radial-gradient(circle, rgba(255, 140, 0, 0.6), rgba(255, 140, 0, 0));
+    filter: blur(12px);
+    opacity: 0.75;
+}
+
+.photo-frame {
+    position: absolute;
+    width: 200px;
+    aspect-ratio: 2 / 3;
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 24px 48px rgba(4, 19, 43, 0.4);
+    border: 2px solid rgba(155, 214, 255, 0.35);
+    backdrop-filter: blur(4px);
+    background: linear-gradient(135deg, rgba(24, 160, 199, 0.25), rgba(9, 43, 86, 0.65));
+    transition: transform 0.5s ease, box-shadow 0.5s ease;
+}
+
+.photo-frame img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: saturate(1.15);
+}
+
+.photo-frame figcaption {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 12px 16px;
+    background: linear-gradient(180deg, transparent 0%, rgba(4, 19, 43, 0.9) 70%);
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.photo-frame.hero-left {
+    top: 40px;
+    left: -60px;
+    transform: rotate(-5deg);
+}
+
+.photo-frame.hero-right {
+    bottom: 30px;
+    right: -60px;
+    transform: rotate(4deg);
+}
+
+.photo-frame:hover {
+    transform: translateY(-6px) scale(1.02);
+    box-shadow: 0 28px 56px rgba(4, 19, 43, 0.55);
+}
+
+.bar {
+    width: 14px;
+    border-radius: 999px 999px 0 0;
+    background: linear-gradient(to top, rgba(255, 138, 0, 0.9), rgba(255, 214, 145, 0.85));
+    box-shadow: 0 0 18px rgba(255, 140, 0, 0.6);
+    animation: equalizer 1.9s ease-in-out infinite;
+    animation-delay: calc(var(--i) * 0.08s);
+    transform-origin: bottom center;
+    opacity: 0.92;
+}
+
+.bar:nth-child(odd) {
+    animation-duration: 1.6s;
+}
+
+.bar:nth-child(4n) {
+    animation-duration: 2.2s;
+}
+
+@keyframes equalizer {
+    0%, 100% { transform: scaleY(0.25); }
+    20% { transform: scaleY(0.8); }
+    40% { transform: scaleY(0.45); }
+    60% { transform: scaleY(1); }
+    80% { transform: scaleY(0.5); }
+}
+
+@keyframes burst-rotate {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@keyframes rays-pulse {
+    0%, 100% { transform: scale(0.92); opacity: 0.55; }
+    50% { transform: scale(1.05); opacity: 0.85; }
+}
+
 /* --- Animaties --- */
 @keyframes neon-flicker {
     0%, 19%, 21%, 23%, 25%, 54%, 56%, 100% {
@@ -309,6 +595,88 @@ header p {
 #theme-arburg { background: linear-gradient(45deg, var(--primary-green), var(--accent-brown)); }
 #theme-rave { background: linear-gradient(45deg, var(--rave-lime), var(--rave-magenta)); }
 
+.photo-gallery {
+    text-align: center;
+}
+
+.photo-gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 16px;
+    margin-top: 1rem;
+}
+
+.photo-card {
+    position: relative;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid rgba(155, 214, 255, 0.35);
+    background: linear-gradient(160deg, rgba(9, 43, 86, 0.7), rgba(4, 19, 43, 0.85));
+    box-shadow: 0 16px 32px rgba(4, 19, 43, 0.35);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.photo-card img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.photo-card figcaption {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 0.6rem 0.8rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    background: linear-gradient(180deg, transparent 0%, rgba(4, 19, 43, 0.9) 80%);
+}
+
+.photo-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 24px 48px rgba(4, 19, 43, 0.45);
+}
+
+.photo-collage {
+    position: relative;
+}
+
+.photo-collage-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 18px;
+    margin-top: 1.5rem;
+}
+
+.collage-card {
+    position: relative;
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid rgba(24, 160, 199, 0.35);
+    box-shadow: 0 22px 44px rgba(4, 19, 43, 0.38);
+    background: linear-gradient(160deg, rgba(4, 19, 43, 0.85), rgba(9, 43, 86, 0.75));
+}
+
+.collage-card img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.collage-card figcaption {
+    position: absolute;
+    inset: auto 0 0 0;
+    padding: 0.75rem 1rem;
+    background: linear-gradient(180deg, transparent 0%, rgba(4, 19, 43, 0.95) 85%);
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
 /* --- Autoplay & Fout Overlay --- */
 #start-btn { border: 3px solid var(--primary-accent); color: var(--primary-accent); }
 #start-btn:hover, #start-btn:disabled { background: var(--primary-accent); color: var(--bg-dark); box-shadow: 0 0 25px var(--primary-accent); }
@@ -506,8 +874,22 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
 /* --- Responsiviteit --- */
 @media (max-width: 900px) {
     body { padding: 10px; padding-bottom: 80px; }
+    #visualizer-showcase { min-height: 420px; padding: 24px 16px 80px; margin: 30px auto 40px; }
+    .logo-card { padding: 32px 24px 40px; border-radius: 28px; }
+    .logo-header { flex-direction: column; gap: 12px; align-items: center; }
+    .logo-tagline { text-align: center; letter-spacing: 0.18em; }
+    .logo-emblem { transform: scale(0.85); margin: 24px auto; }
+    .visualizer-bars { height: 140px; gap: 4px; padding: 0 12px; }
+    .bar { width: 10px; }
+    .photo-frame {
+        position: static;
+        width: min(180px, 60vw);
+        margin: 12px auto 0;
+        transform: none;
+    }
+    .photo-frame figcaption { font-size: 0.7rem; }
     #app-container { flex-direction: column; }
-    
+
     #radio-view { flex-direction: column; }
 
     #side-panel { 
@@ -547,4 +929,17 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
         font-size: 24px; 
         cursor: pointer; 
     }
+}
+
+@media (max-width: 600px) {
+    #visualizer-showcase { min-height: 360px; padding: 20px 12px 70px; }
+    .logo-card { padding: 28px 18px 34px; }
+    .logo-ib { font-size: 3.6rem; letter-spacing: -4px; }
+    .logo-tagline { font-size: 0.85rem; letter-spacing: 0.14em; }
+    .logo-emblem { transform: scale(0.72); }
+    .wordmark-primary { font-size: 1.35rem; }
+    .wordmark-secondary { font-size: 0.65rem; letter-spacing: 0.32em; }
+    .visualizer-bars { height: 110px; }
+    .photo-gallery-grid { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+    .photo-collage-grid { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
## Summary
- add a standalone visualizer hero section with concentric glow and animated bars
- recreate the ib In Team Betrouwbaar Daremon Solutions logo in accessible markup at the center of the hero
- tune responsive styles for the new hero layout on smaller screens
- add styled photo showcases throughout the layout with localized captions

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc89e117908322a23ebb7b1d5be697