### PR TITLE
feat: display track artwork in side panel lists

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 import { waitForMediaReady } from './media-utils.js';
 import { createInitialState } from './state.js';
+import { createTrackListItem } from './ui-utils.js';
 
 /**
  * DAREMON Radio ETS - Hoofdlogica van de applicatie v8
@@ -607,9 +608,12 @@ document.addEventListener('DOMContentLoaded', () => {
             state.history.forEach(trackId => {
                 const track = state.playlist.find(t => t.id === trackId);
                 if (track) {
-                    const li = document.createElement('li');
-                    li.textContent = `${track.artist} - ${track.title}`;
-                    dom.sidePanel.historyList.appendChild(li);
+                    const item = createTrackListItem(track, {
+                        subtitle: Array.isArray(track.tags) && track.tags.length > 0
+                            ? track.tags.slice(0, 2).join(', ')
+                            : ''
+                    });
+                    dom.sidePanel.historyList.appendChild(item);
                 }
             });
         }
@@ -763,11 +767,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
         dom.sidePanel.topRatedList.innerHTML = '';
         ratedTracks.slice(0, 5).forEach(track => {
-            const li = document.createElement('li');
-            li.textContent = `${track.artist} - ${track.title} (${track.avgRating.toFixed(1)} ⭐)`;
-            li.dataset.trackId = track.id;
-            li.addEventListener('click', () => playTrackNow(track));
-            dom.sidePanel.topRatedList.appendChild(li);
+            const subtitle = `${track.avgRating.toFixed(1)} ⭐ · ${track.reviewCount}`;
+            const item = createTrackListItem(track, {
+                subtitle,
+                interactive: true,
+                onActivate: () => playTrackNow(track)
+            });
+            dom.sidePanel.topRatedList.appendChild(item);
         });
     }
 
@@ -788,18 +794,18 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Gouden Platen & Berichten ---
     function renderGoldenRecords() { 
         if (!dom.sidePanel.goldenRecordsList) return;
-        const goldenTracks = state.playlist.filter(t => t.golden); 
-        dom.sidePanel.goldenRecordsList.innerHTML = ''; 
-        goldenTracks.forEach(track => { 
-            const li = document.createElement('li'); 
-            li.textContent = `${track.artist} - ${track.title}`; 
-            li.dataset.trackId = track.id; 
-            li.addEventListener('click', () => { 
-                const trackToPlay = state.playlist.find(t => t.id === li.dataset.trackId); 
-                playTrackNow(trackToPlay); 
-            }); 
-            dom.sidePanel.goldenRecordsList.appendChild(li); 
-        }); 
+        const goldenTracks = state.playlist.filter(t => t.golden);
+        dom.sidePanel.goldenRecordsList.innerHTML = '';
+        goldenTracks.forEach(track => {
+            const item = createTrackListItem(track, {
+                subtitle: Array.isArray(track.tags) && track.tags.length > 0
+                    ? track.tags.slice(0, 2).join(', ')
+                    : '',
+                interactive: true,
+                onActivate: () => playTrackNow(track)
+            });
+            dom.sidePanel.goldenRecordsList.appendChild(item);
+        });
     }
 
     function handleLike() {

--- a/styles.css
+++ b/styles.css
@@ -566,18 +566,48 @@ header p {
 }
 #menu-toggle { display: none; }
 .side-panel-list { list-style: none; padding: 0; margin: 0; max-height: 150px; overflow-y: auto; }
-.side-panel-list li { padding: 8px; border-bottom: 1px solid #333; font-size: 0.9em; transition: background-color 0.2s; }
+.side-panel-list li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px;
+    border-bottom: 1px solid #333;
+    font-size: 0.9em;
+    transition: background-color 0.2s, transform 0.2s;
+}
+.track-list-cover {
+    width: 48px;
+    height: 48px;
+    border-radius: 10px;
+    object-fit: cover;
+    flex-shrink: 0;
+    box-shadow: 0 6px 15px rgba(9, 43, 86, 0.45);
+}
+.track-list-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.track-list-title {
+    font-weight: 600;
+}
+.track-list-meta {
+    font-size: 0.7rem;
+    letter-spacing: 0.02em;
+    color: rgba(244, 247, 251, 0.7);
+}
 .interactive-list li { cursor: pointer; }
-.interactive-list li:hover { background-color: rgba(0, 136, 120, 0.2); }
-#golden-records-list li, #top-rated-list li {
+.interactive-list li:hover { background-color: rgba(0, 136, 120, 0.2); transform: translateX(4px); }
+.interactive-list li:focus-visible {
+    outline: 2px solid var(--primary-accent);
+    outline-offset: 2px;
+    background-color: rgba(0, 136, 120, 0.25);
+}
+#golden-records-list .track-list-title {
     color: #ffd700;
     text-shadow: 0 0 5px #ffd700;
 }
-#golden-records-list li::before, #top-rated-list li::before {
-    content: '⭐';
-    margin-right: 8px;
-}
-#top-rated-list li {
+#top-rated-list .track-list-title {
     color: var(--primary-accent);
     text-shadow: 0 0 5px var(--primary-accent);
 }

--- a/tests/ui-utils.test.js
+++ b/tests/ui-utils.test.js
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTrackListItem } from '../ui-utils.js';
+
+class FakeElement extends EventTarget {
+    constructor(tagName) {
+        super();
+        this.tagName = tagName.toUpperCase();
+        this.children = [];
+        this.attributes = {};
+        this.className = '';
+        this.style = {};
+        this.dataset = {};
+        this._textContent = '';
+        const classSet = new Set();
+        this.classList = {
+            add: (...classes) => {
+                classes.forEach(cls => classSet.add(cls));
+                this.className = Array.from(classSet).join(' ');
+            },
+            contains: (cls) => classSet.has(cls)
+        };
+    }
+
+    appendChild(child) {
+        this.children.push(child);
+        return child;
+    }
+
+    setAttribute(name, value) {
+        this.attributes[name] = String(value);
+    }
+
+    getAttribute(name) {
+        return this.attributes[name];
+    }
+
+    set textContent(value) {
+        this._textContent = value;
+    }
+
+    get textContent() {
+        return this._textContent;
+    }
+}
+
+describe('createTrackListItem', () => {
+    let originalDocument;
+
+    beforeEach(() => {
+        originalDocument = globalThis.document;
+        globalThis.document = {
+            createElement: (tagName) => new FakeElement(tagName)
+        };
+    });
+
+    afterEach(() => {
+        globalThis.document = originalDocument;
+    });
+
+    it('renders a list item with cover art and optional subtitle', () => {
+        const track = { id: 'track-1', artist: 'DJ Test', title: 'Sample', cover: 'cover.png' };
+
+        const item = createTrackListItem(track, { subtitle: '4.5 ⭐ · 3' });
+
+        expect(item.classList.contains('track-list-item')).toBe(true);
+        expect(item.dataset.trackId).toBe('track-1');
+
+        const [cover, infoWrapper] = item.children;
+        expect(cover.tagName).toBe('IMG');
+        expect(cover.src).toBe('cover.png');
+        expect(cover.alt).toBe('DJ Test – Sample');
+
+        expect(infoWrapper.children).toHaveLength(2);
+        expect(infoWrapper.children[0].textContent).toBe('DJ Test - Sample');
+        expect(infoWrapper.children[1].textContent).toBe('4.5 ⭐ · 3');
+    });
+
+    it('creates interactive list items that respond to click and keyboard', () => {
+        const track = { id: 'track-2', artist: 'DJ Test', title: 'Interactive', cover: '' };
+        const onActivate = vi.fn();
+
+        const item = createTrackListItem(track, { interactive: true, onActivate });
+
+        expect(item.getAttribute('role')).toBe('button');
+        expect(item.tabIndex).toBe(0);
+
+        item.dispatchEvent(new Event('click'));
+
+        const keyEvent = new Event('keydown');
+        keyEvent.key = 'Enter';
+        item.dispatchEvent(keyEvent);
+
+        expect(onActivate).toHaveBeenCalledTimes(2);
+    });
+});

--- a/ui-utils.js
+++ b/ui-utils.js
@@ -1,0 +1,65 @@
+const FALLBACK_COVER = 'https://placehold.co/120x120/1A1A1A/FFFFFF?text=DAREMON';
+
+function buildSubtitle(subtitle) {
+    return typeof subtitle === 'string' ? subtitle.trim() : '';
+}
+
+export function createTrackListItem(track, options = {}) {
+    if (!track) {
+        throw new Error('Track details are required to build a list item');
+    }
+
+    const { subtitle = '', interactive = false, onActivate } = options;
+
+    const listItem = document.createElement('li');
+    listItem.classList.add('track-list-item');
+    if (track.id) {
+        listItem.dataset.trackId = track.id;
+    }
+
+    const cover = document.createElement('img');
+    cover.classList.add('track-list-cover');
+    cover.src = track.cover || FALLBACK_COVER;
+    cover.alt = `${track.artist} – ${track.title}`;
+    cover.loading = 'lazy';
+    cover.decoding = 'async';
+
+    const infoWrapper = document.createElement('div');
+    infoWrapper.classList.add('track-list-info');
+
+    const title = document.createElement('span');
+    title.classList.add('track-list-title');
+    title.textContent = `${track.artist} - ${track.title}`;
+    infoWrapper.appendChild(title);
+
+    const subtitleText = buildSubtitle(subtitle);
+    if (subtitleText) {
+        const meta = document.createElement('span');
+        meta.classList.add('track-list-meta');
+        meta.textContent = subtitleText;
+        infoWrapper.appendChild(meta);
+    }
+
+    listItem.appendChild(cover);
+    listItem.appendChild(infoWrapper);
+
+    if (interactive && typeof onActivate === 'function') {
+        const activate = () => onActivate(track);
+        listItem.setAttribute('role', 'button');
+        listItem.tabIndex = 0;
+
+        listItem.addEventListener('click', (event) => {
+            event.preventDefault();
+            activate();
+        });
+
+        listItem.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                activate();
+            }
+        });
+    }
+
+    return listItem;
+}


### PR DESCRIPTION
## Summary
- render playlist cover art inside history, top rated, and golden record panels using a shared helper
- refine drawer list styling for the new artwork layout and keyboard focus states
- add unit tests for the track list helper to ensure accessible behaviour

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e421bb26508322b1ba72a8c2b44589