### PR TITLE
feat: restyle hero visualizer to match Daremon branding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -74,13 +74,24 @@ body {
 #visualizer-showcase {
     position: relative;
     width: 100%;
-    max-width: 960px;
-    min-height: 520px;
-    margin: 40px auto 60px;
+    max-width: 900px;
+    min-height: 540px;
+    margin: 40px auto 70px;
+    padding: 140px 80px 180px;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
+    border-radius: 48px;
+    background:
+        radial-gradient(circle at center, rgba(255, 176, 43, 0.18) 0%, rgba(11, 31, 58, 0.85) 38%, rgba(3, 10, 29, 0.98) 85%),
+        linear-gradient(160deg, rgba(4, 12, 28, 0.96), rgba(7, 21, 47, 0.94));
+    box-shadow:
+        0 50px 120px rgba(2, 9, 24, 0.78),
+        inset 0 0 0 1px rgba(126, 224, 255, 0.08);
+    border: 1px solid rgba(24, 160, 199, 0.16);
+    overflow: hidden;
+    isolation: isolate;
 }
 
 .visualizer-glow {
@@ -95,46 +106,102 @@ body {
 .visualizer-glow::before {
     content: "";
     position: absolute;
-    width: 760px;
-    height: 760px;
+    width: 780px;
+    height: 780px;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(255, 164, 0, 0.25) 0%, rgba(4, 19, 43, 0) 65%);
-    filter: blur(4px);
+    background:
+        radial-gradient(circle at center, rgba(255, 181, 69, 0.75) 0%, rgba(255, 140, 0, 0.32) 26%, rgba(4, 19, 43, 0) 68%);
+    filter: blur(2px);
+    opacity: 0.9;
+    mix-blend-mode: screen;
+}
+
+.visualizer-glow::after {
+    content: "";
+    position: absolute;
+    width: 720px;
+    height: 720px;
+    border-radius: 50%;
+    background:
+        conic-gradient(from 90deg,
+            transparent 0deg 8deg,
+            rgba(255, 189, 77, 0.78) 8deg 10deg,
+            transparent 10deg 30deg,
+            rgba(255, 147, 24, 0.82) 30deg 32deg,
+            transparent 32deg 360deg);
+    mask: radial-gradient(circle, transparent 54%, rgba(0, 0, 0, 0.82) 57%, rgba(0, 0, 0, 0.9) 63%, transparent 65%);
+    opacity: 0.9;
+    animation: glow-rotate 18s linear infinite;
+    mix-blend-mode: screen;
 }
 
 .visualizer-burst {
     width: 520px;
     height: 520px;
     border-radius: 50%;
-    background: conic-gradient(from 0deg, rgba(255, 164, 0, 0.35), rgba(255, 210, 99, 0.05), rgba(255, 164, 0, 0.35));
-    mask: radial-gradient(circle, transparent 0%, transparent 45%, black 46%);
-    animation: burst-rotate 12s linear infinite;
+    position: relative;
+    background:
+        radial-gradient(circle at center, rgba(255, 199, 112, 0.75) 0%, rgba(255, 199, 112, 0.35) 32%, rgba(255, 176, 43, 0) 64%),
+        conic-gradient(from 0deg, rgba(255, 176, 43, 0.7), rgba(255, 214, 145, 0.05), rgba(255, 176, 43, 0.7));
+    mask: radial-gradient(circle, transparent 0%, transparent 46%, black 47%);
+    box-shadow: 0 0 65px rgba(255, 163, 26, 0.45);
+    animation: burst-rotate 22s linear infinite;
 }
 
 .visualizer-rays {
     position: absolute;
-    width: 640px;
-    height: 640px;
+    width: 680px;
+    height: 680px;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(255, 181, 69, 0.18) 0%, rgba(255, 181, 69, 0) 60%);
-    animation: rays-pulse 6s ease-in-out infinite;
+    background:
+        radial-gradient(circle, rgba(255, 201, 128, 0.35) 0%, rgba(255, 201, 128, 0.05) 45%, rgba(255, 201, 128, 0) 60%),
+        repeating-conic-gradient(from 0deg, rgba(255, 189, 77, 0.36) 0deg 2deg, rgba(255, 189, 77, 0.04) 2deg 12deg);
+    mask: radial-gradient(circle, transparent 0%, transparent 52%, rgba(0, 0, 0, 0.65) 54%, transparent 70%);
+    animation: rays-pulse 7s ease-in-out infinite;
+    mix-blend-mode: screen;
 }
 
 .logo-card {
     position: relative;
     z-index: 2;
-    padding: 48px 64px 56px;
-    border-radius: 36px;
-    background: radial-gradient(circle at 30% 20%, rgba(31, 88, 148, 0.55), rgba(4, 19, 43, 0.95));
-    backdrop-filter: blur(14px);
-    box-shadow: 0 32px 80px rgba(4, 19, 43, 0.75), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(24, 160, 199, 0.4);
+    padding: 56px 72px 64px;
+    border-radius: 42px;
+    background:
+        radial-gradient(circle at 20% 20%, rgba(45, 122, 201, 0.28), transparent 65%),
+        linear-gradient(160deg, rgba(3, 18, 40, 0.96), rgba(6, 31, 68, 0.98));
+    backdrop-filter: blur(16px);
+    box-shadow:
+        0 36px 120px rgba(4, 19, 43, 0.78),
+        inset 0 0 0 1px rgba(118, 205, 255, 0.1);
+    border: 1px solid rgba(36, 103, 171, 0.35);
+    isolation: isolate;
+    color: #f1f6ff;
+}
+
+.logo-card::before {
+    content: "";
+    position: absolute;
+    inset: 14px;
+    border-radius: 32px;
+    background: radial-gradient(circle at top, rgba(126, 224, 255, 0.22), transparent 70%);
+    opacity: 0.55;
+    pointer-events: none;
+}
+
+.logo-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 42px;
+    box-shadow: inset 0 0 22px rgba(255, 189, 77, 0.12);
+    mix-blend-mode: screen;
+    pointer-events: none;
 }
 
 .logo-header {
     display: flex;
     align-items: flex-end;
-    gap: 24px;
+    gap: 28px;
     justify-content: center;
 }
 
@@ -143,28 +210,32 @@ body {
     font-weight: 700;
     letter-spacing: -6px;
     text-transform: lowercase;
-    color: #d1d5db;
-    text-shadow: 0 0 16px rgba(255, 255, 255, 0.35);
+    color: #ecf3ff;
+    text-shadow:
+        0 0 12px rgba(126, 224, 255, 0.55),
+        0 0 42px rgba(126, 224, 255, 0.35);
 }
 
 .logo-ib span {
     display: inline-block;
-    color: #f7f7f7;
+    color: #ffffff;
     font-weight: 800;
     transform: translateX(-10px);
+    text-shadow: 0 0 16px rgba(255, 255, 255, 0.65);
 }
 
 .logo-tagline {
     display: grid;
     text-transform: uppercase;
-    font-size: clamp(0.9rem, 2vw, 1.1rem);
+    font-size: clamp(0.95rem, 2.2vw, 1.15rem);
     row-gap: 2px;
-    letter-spacing: 0.28em;
+    letter-spacing: 0.3em;
     text-align: left;
+    color: rgba(155, 214, 255, 0.85);
 }
 
 .logo-in {
-    color: #7ee0ff;
+    color: #9bd6ff;
 }
 
 .logo-team {
@@ -173,7 +244,7 @@ body {
 }
 
 .logo-betrouwbaar {
-    color: #b7d4ff;
+    color: #d4e8ff;
     font-weight: 300;
     letter-spacing: 0.24em;
 }
@@ -183,6 +254,7 @@ body {
     width: 220px;
     height: 220px;
     margin: 36px auto 28px;
+    filter: drop-shadow(0 0 22px rgba(126, 224, 255, 0.35));
 }
 
 .logo-emblem .ring {
@@ -225,7 +297,9 @@ body {
     height: 26px;
     border-radius: 50%;
     background: linear-gradient(135deg, #7ee0ff, #18a0c7);
-    box-shadow: 0 0 18px rgba(126, 224, 255, 0.8);
+    box-shadow:
+        0 0 18px rgba(126, 224, 255, 0.9),
+        0 0 38px rgba(126, 224, 255, 0.6);
 }
 
 .logo-wordmark {
@@ -238,97 +312,54 @@ body {
 .wordmark-primary {
     font-size: clamp(1.6rem, 5vw, 2.2rem);
     font-weight: 800;
+    color: #eaf3ff;
+    text-shadow: 0 0 16px rgba(126, 224, 255, 0.35);
 }
 
 .wordmark-secondary {
     font-size: clamp(0.75rem, 2.5vw, 1rem);
     font-weight: 500;
-    color: rgba(255, 255, 255, 0.75);
+    color: rgba(155, 214, 255, 0.78);
     letter-spacing: 0.48em;
+    text-shadow: 0 0 14px rgba(126, 224, 255, 0.28);
 }
 
 .visualizer-bars {
     position: absolute;
-    bottom: 0;
+    bottom: 40px;
     left: 50%;
     transform: translateX(-50%);
     display: flex;
     align-items: flex-end;
     gap: 6px;
-    padding: 0 24px;
+    padding: 0 28px;
     height: 180px;
 }
 
-.visualizer-bars::after {
+.visualizer-bars::before {
     content: "";
     position: absolute;
-    bottom: -24px;
-    left: 0;
-    right: 0;
-    height: 40px;
-    background: radial-gradient(circle, rgba(255, 140, 0, 0.6), rgba(255, 140, 0, 0));
-    filter: blur(12px);
-    opacity: 0.75;
+    inset: auto 14px -32px 14px;
+    height: 44px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 170, 43, 0.65) 0%, rgba(255, 170, 43, 0));
+    filter: blur(18px);
+    opacity: 0.8;
 }
 
-.photo-frame {
-    position: absolute;
-    width: 200px;
-    aspect-ratio: 2 / 3;
-    border-radius: 18px;
-    overflow: hidden;
-    box-shadow: 0 24px 48px rgba(4, 19, 43, 0.4);
-    border: 2px solid rgba(155, 214, 255, 0.35);
-    backdrop-filter: blur(4px);
-    background: linear-gradient(135deg, rgba(24, 160, 199, 0.25), rgba(9, 43, 86, 0.65));
-    transition: transform 0.5s ease, box-shadow 0.5s ease;
-}
-
-.photo-frame img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    filter: saturate(1.15);
-}
-
-.photo-frame figcaption {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    padding: 12px 16px;
-    background: linear-gradient(180deg, transparent 0%, rgba(4, 19, 43, 0.9) 70%);
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
-.photo-frame.hero-left {
-    top: 40px;
-    left: -60px;
-    transform: rotate(-5deg);
-}
-
-.photo-frame.hero-right {
-    bottom: 30px;
-    right: -60px;
-    transform: rotate(4deg);
-}
-
-.photo-frame:hover {
-    transform: translateY(-6px) scale(1.02);
-    box-shadow: 0 28px 56px rgba(4, 19, 43, 0.55);
-}
+.photo-frame { display: none; }
 
 .bar {
     width: 14px;
     border-radius: 999px 999px 0 0;
-    background: linear-gradient(to top, rgba(255, 138, 0, 0.9), rgba(255, 214, 145, 0.85));
-    box-shadow: 0 0 18px rgba(255, 140, 0, 0.6);
+    background: linear-gradient(to top, rgba(255, 140, 0, 0.95), rgba(255, 215, 156, 0.9));
+    box-shadow:
+        0 0 14px rgba(255, 140, 0, 0.9),
+        0 0 38px rgba(255, 171, 60, 0.55);
     animation: equalizer 1.9s ease-in-out infinite;
     animation-delay: calc(var(--i) * 0.08s);
     transform-origin: bottom center;
-    opacity: 0.92;
+    opacity: 0.95;
 }
 
 .bar:nth-child(odd) {
@@ -341,10 +372,10 @@ body {
 
 @keyframes equalizer {
     0%, 100% { transform: scaleY(0.25); }
-    20% { transform: scaleY(0.8); }
-    40% { transform: scaleY(0.45); }
-    60% { transform: scaleY(1); }
-    80% { transform: scaleY(0.5); }
+    20% { transform: scaleY(0.82); }
+    40% { transform: scaleY(0.48); }
+    60% { transform: scaleY(1.05); }
+    80% { transform: scaleY(0.52); }
 }
 
 @keyframes burst-rotate {
@@ -352,9 +383,14 @@ body {
     to { transform: rotate(360deg); }
 }
 
+@keyframes glow-rotate {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(-360deg); }
+}
+
 @keyframes rays-pulse {
-    0%, 100% { transform: scale(0.92); opacity: 0.55; }
-    50% { transform: scale(1.05); opacity: 0.85; }
+    0%, 100% { transform: scale(0.92); opacity: 0.58; }
+    50% { transform: scale(1.06); opacity: 0.92; }
 }
 
 /* --- Animaties --- */
@@ -874,20 +910,13 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
 /* --- Responsiviteit --- */
 @media (max-width: 900px) {
     body { padding: 10px; padding-bottom: 80px; }
-    #visualizer-showcase { min-height: 420px; padding: 24px 16px 80px; margin: 30px auto 40px; }
-    .logo-card { padding: 32px 24px 40px; border-radius: 28px; }
-    .logo-header { flex-direction: column; gap: 12px; align-items: center; }
-    .logo-tagline { text-align: center; letter-spacing: 0.18em; }
-    .logo-emblem { transform: scale(0.85); margin: 24px auto; }
-    .visualizer-bars { height: 140px; gap: 4px; padding: 0 12px; }
+    #visualizer-showcase { min-height: 480px; padding: 110px 48px 150px; margin: 30px auto 50px; border-radius: 40px; }
+    .logo-card { padding: 44px 36px 52px; border-radius: 34px; }
+    .logo-header { flex-direction: column; gap: 16px; align-items: center; }
+    .logo-tagline { text-align: center; letter-spacing: 0.22em; }
+    .logo-emblem { transform: scale(0.85); margin: 22px auto; }
+    .visualizer-bars { height: 150px; gap: 4px; padding: 0 16px; bottom: 26px; }
     .bar { width: 10px; }
-    .photo-frame {
-        position: static;
-        width: min(180px, 60vw);
-        margin: 12px auto 0;
-        transform: none;
-    }
-    .photo-frame figcaption { font-size: 0.7rem; }
     #app-container { flex-direction: column; }
 
     #radio-view { flex-direction: column; }
@@ -932,14 +961,15 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
 }
 
 @media (max-width: 600px) {
-    #visualizer-showcase { min-height: 360px; padding: 20px 12px 70px; }
-    .logo-card { padding: 28px 18px 34px; }
-    .logo-ib { font-size: 3.6rem; letter-spacing: -4px; }
-    .logo-tagline { font-size: 0.85rem; letter-spacing: 0.14em; }
-    .logo-emblem { transform: scale(0.72); }
+    #visualizer-showcase { min-height: 420px; padding: 90px 28px 140px; border-radius: 32px; }
+    .logo-card { padding: 34px 22px 40px; border-radius: 26px; }
+    .logo-ib { font-size: 3.7rem; letter-spacing: -4px; }
+    .logo-tagline { font-size: 0.9rem; letter-spacing: 0.18em; }
+    .logo-emblem { transform: scale(0.7); }
     .wordmark-primary { font-size: 1.35rem; }
     .wordmark-secondary { font-size: 0.65rem; letter-spacing: 0.32em; }
-    .visualizer-bars { height: 110px; }
+    .visualizer-bars { height: 130px; bottom: 20px; }
+    .bar { width: 9px; }
     .photo-gallery-grid { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
     .photo-collage-grid { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
## Summary
- restyled the hero visualizer container with layered gradients, animated burst, and enhanced equalizer lighting to reflect the provided artwork
- refreshed the logo card typography and glow effects while removing the legacy photo frames for a focused composition

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e42383d0c883228a8096b1ec173f56