### PR TITLE
feat: add video gallery placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,6 +239,35 @@
                         </figure>
                     </div>
                 </section>
+                <section id="video-library" class="content-box video-library" aria-labelledby="video-library-title">
+                    <div class="video-library-header">
+                        <h2 id="video-library-title" data-i18n-key="videoLibraryTitle"></h2>
+                        <p class="section-intro" data-i18n-key="videoLibraryIntro"></p>
+                    </div>
+                    <div class="video-grid">
+                        <figure class="video-card">
+                            <video controls preload="metadata" poster="https://placehold.co/320x180/082552/18A0C7?text=DJ+Daremon" aria-describedby="video-dj-daremon-caption">
+                                <source src="video/DJ_Daremon.mp4" type="video/mp4">
+                                <p data-i18n-key="videoFallback"></p>
+                            </video>
+                            <figcaption id="video-dj-daremon-caption" data-i18n-key="videoDJDaremon"></figcaption>
+                        </figure>
+                        <figure class="video-card">
+                            <video controls preload="metadata" poster="https://placehold.co/320x180/04132B/9BD6FF?text=DJ+Bobro" aria-describedby="video-dj-bobro-caption">
+                                <source src="video/DJ_Bobro.mp4" type="video/mp4">
+                                <p data-i18n-key="videoFallback"></p>
+                            </video>
+                            <figcaption id="video-dj-bobro-caption" data-i18n-key="videoDJBobro"></figcaption>
+                        </figure>
+                        <figure class="video-card">
+                            <video controls preload="metadata" poster="https://placehold.co/320x180/0B1F3A/9BD6FF?text=Beaver" aria-describedby="video-beaver-caption">
+                                <source src="video/Beaver.mp4" type="video/mp4">
+                                <p data-i18n-key="videoFallback"></p>
+                            </video>
+                            <figcaption id="video-beaver-caption" data-i18n-key="videoBeaver"></figcaption>
+                        </figure>
+                    </div>
+                </section>
                 <div id="hotkeys-info" data-i18n-key="hotkeysInfo"></div>
             </main>
 

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -89,5 +89,11 @@
   "teamMomentsIntro": "Ontdek de sfeer achter de schermen met snapshots uit het DAREMON Radio ETS-team.",
   "teamMomentsCaptionPrep": "Voorbereiding achter de schermen",
   "teamMomentsCaptionInterview": "Interview met speciale gast",
-  "teamMomentsCaptionCommunity": "Community interactie"
+  "teamMomentsCaptionCommunity": "Community interactie",
+  "videoLibraryTitle": "Videomomenten",
+  "videoLibraryIntro": "Duik in de meest gevraagde clips rechtstreeks vanuit de DAREMON studio.",
+  "videoFallback": "Je browser ondersteunt deze video niet.",
+  "videoDJDaremon": "DJ DAREMON live-set",
+  "videoDJBobro": "DJ Bobro in de studio",
+  "videoBeaver": "Beaver aftermovie"
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -89,5 +89,11 @@
   "teamMomentsIntro": "Zobacz kulisy działania DAREMON Radio ETS na wybranych fotografiach.",
   "teamMomentsCaptionPrep": "Przygotowania za kulisami",
   "teamMomentsCaptionInterview": "Wywiad ze specjalnym gościem",
-  "teamMomentsCaptionCommunity": "Interakcje ze słuchaczami"
+  "teamMomentsCaptionCommunity": "Interakcje ze słuchaczami",
+  "videoLibraryTitle": "Wideoteka",
+  "videoLibraryIntro": "Obejrzyj najpopularniejsze nagrania prosto ze studia DAREMON.",
+  "videoFallback": "Twoja przeglądarka nie obsługuje wideo.",
+  "videoDJDaremon": "DJ DAREMON – set na żywo",
+  "videoDJBobro": "DJ Bobro w studiu",
+  "videoBeaver": "Beaver – aftermovie"
 }

--- a/styles.css
+++ b/styles.css
@@ -677,6 +677,52 @@ header p {
     text-transform: uppercase;
 }
 
+.video-library {
+    position: relative;
+}
+
+.video-library-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.video-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+}
+
+.video-card {
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(160deg, rgba(4, 19, 43, 0.85), rgba(9, 43, 86, 0.75));
+    border-radius: 18px;
+    border: 1px solid rgba(24, 160, 199, 0.35);
+    box-shadow: 0 22px 44px rgba(4, 19, 43, 0.38);
+    overflow: hidden;
+}
+
+.video-card video {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: #000;
+    border-bottom: 1px solid rgba(24, 160, 199, 0.35);
+}
+
+.video-card video:focus-visible {
+    outline: 3px solid var(--secondary-accent);
+    outline-offset: 0;
+}
+
+.video-card figcaption {
+    padding: 0.9rem 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.8rem;
+}
+
 /* --- Autoplay & Fout Overlay --- */
 #start-btn { border: 3px solid var(--primary-accent); color: var(--primary-accent); }
 #start-btn:hover, #start-btn:disabled { background: var(--primary-accent); color: var(--bg-dark); box-shadow: 0 0 25px var(--primary-accent); }
@@ -911,8 +957,9 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
     #main-content { max-width: 100%; }
     #player-ui { flex-direction: column; text-align: center; }
     #track-cover { width: 150px; height: 150px; }
-    
-    #menu-toggle { 
+    .video-grid { grid-template-columns: 1fr; }
+
+    #menu-toggle {
         display: flex; 
         justify-content: center; 
         align-items: center; 
@@ -942,4 +989,5 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
     .visualizer-bars { height: 110px; }
     .photo-gallery-grid { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
     .photo-collage-grid { grid-template-columns: 1fr; }
+    .video-card figcaption { text-align: center; }
 }


### PR DESCRIPTION
## Summary
- add a video library section with placeholders for DJ Daremon, DJ Bobro, and Beaver clips
- style the new gallery with responsive layout and focus-visible handling
- localize the new copy and add a placeholder directory for video assets

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e423cce7348322a2f8c8df86a925a1