### PR TITLE
fix: center now playing logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,11 +188,12 @@
                 </header>
 
                 <section id="now-playing-section" class="content-box">
-                    <img id="daremon-logo" src="images/icons/logo.png" alt="Logo DAREMON Solutions" role="img" aria-label="Logo DAREMON Solutions">
-                    <div id="player-ui">
-                        <img id="track-cover" src="https://placehold.co/120x120/04132B/18A0C7?text=ETS" alt="Okładka aktualnego utworu">
-                        <div id="track-info">
-                            <h2 id="track-title" aria-live="polite" data-i18n-key="trackTitleDefault"></h2>
+                    <div class="now-playing-layout">
+                        <img id="daremon-logo" src="images/icons/logo.png" alt="Logo DAREMON Solutions" role="img" aria-label="Logo DAREMON Solutions">
+                        <div id="player-ui">
+                            <img id="track-cover" src="https://placehold.co/120x120/04132B/18A0C7?text=ETS" alt="Okładka aktualnego utworu">
+                            <div id="track-info">
+                                <h2 id="track-title" aria-live="polite" data-i18n-key="trackTitleDefault"></h2>
                             <h3 id="track-artist" data-i18n-key="trackArtistDefault"></h3>
                             <div id="progress-container" role="slider" data-i18n-aria-label="progressBarLabel" tabindex="0">
                                 <div id="progress-bar"></div>
@@ -209,6 +210,7 @@
                                     <button type="submit" data-i18n-key="submitReview"></button>
                                 </form>
                             </div>
+                        </div>
                         </div>
                     </div>
                     <div id="player-controls">

--- a/styles.css
+++ b/styles.css
@@ -458,6 +458,24 @@ body {
 
 #now-playing-section {
     position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.now-playing-layout {
+    display: grid;
+    grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+    align-items: center;
+    gap: 2rem;
+    width: 100%;
+}
+
+#daremon-logo {
+    width: clamp(120px, 18vw, 200px);
+    height: auto;
+    justify-self: center;
+    display: block;
 }
 
 #player-ui {
@@ -465,6 +483,10 @@ body {
     z-index: 2;
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 1.5rem;
 }
 
 /* --- Header --- */
@@ -997,11 +1019,21 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
 
     #radio-view { flex-direction: column; }
 
-    #side-panel { 
-        width: 100%; 
+    .now-playing-layout {
+        grid-template-columns: 1fr;
+        justify-items: center;
+        gap: 1.5rem;
+    }
+
+    #daremon-logo {
+        margin: 0;
+    }
+
+    #side-panel {
+        width: 100%;
         order: 3;
-        position: fixed; 
-        top: 0; 
+        position: fixed;
+        top: 0;
         left: -100%;
         height: 100%; 
         background: #111; 

--- a/tests/now-playing-layout.test.js
+++ b/tests/now-playing-layout.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const html = readFileSync(resolve(__dirname, '../index.html'), 'utf-8');
+
+describe('now playing layout', () => {
+  it('keeps the Daremon logo centered inside the player layout container', () => {
+    expect(html).toContain('class="now-playing-layout"');
+
+    const sectionMatch = html.match(
+      /<section id="now-playing-section"[\s\S]*?<div class="now-playing-layout">([\s\S]*?)<div id="player-controls">/
+    );
+
+    expect(sectionMatch).toBeTruthy();
+    expect(sectionMatch?.[1]).toContain('<img id="daremon-logo"');
+    expect(sectionMatch?.[1]).toContain('<div id="player-ui">');
+  });
+});


### PR DESCRIPTION
## Summary
- reposition the Daremon logo inside a shared now playing layout wrapper so it sits centered with the player
- size the logo responsively and update the player layout styling for desktop and mobile
- add a regression test that ensures the logo remains inside the now playing layout

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e432d2f8b48322889fe2397863af1a