### PR TITLE
feat: move daremon invitation into player tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,25 +39,40 @@
             <div class="visualizer-burst"></div>
             <div class="visualizer-rays"></div>
         </div>
-        <div class="logo-card" role="img" aria-label="Logo ib In Team Betrouwbaar Daremon Solutions">
-            <div class="logo-header">
-                <span class="logo-ib">i<span>b</span></span>
-                <div class="logo-tagline">
-                    <span class="logo-in">In</span>
-                    <span class="logo-team">Team</span>
-                    <span class="logo-betrouwbaar">Betrouwbaar</span>
+        <div class="visualizer-content" role="group" aria-labelledby="countdown-heading deadline-heading">
+            <img id="daremon-logo" src="images/icons/logo.png" alt="Logo DAREMON Solutions" role="img" aria-label="Logo DAREMON Solutions">
+            <div class="countdown-card" aria-live="polite">
+                <p id="countdown-heading">Odliczanie do nowego rozdziału</p>
+                <div id="countdown-display" role="timer" aria-live="polite" aria-atomic="true">
+                    <span class="countdown-part">
+                        <span id="countdown-days" class="countdown-value">0</span>
+                        <span class="countdown-unit">dni</span>
+                    </span>
+                    <span class="countdown-part">
+                        <span id="countdown-hours" class="countdown-value">0</span>
+                        <span class="countdown-unit">godz.</span>
+                    </span>
+                    <span class="countdown-part">
+                        <span id="countdown-minutes" class="countdown-value">0</span>
+                        <span class="countdown-unit">min</span>
+                    </span>
+                    <span class="countdown-part">
+                        <span id="countdown-seconds" class="countdown-value">0</span>
+                        <span class="countdown-unit">sek</span>
+                    </span>
                 </div>
+                <p id="countdown-status">Do 31 marca 2026 roku pozostało jeszcze sporo czasu na przygotowania.</p>
             </div>
-            <div class="logo-emblem" aria-hidden="true">
-                <span class="ring outer"></span>
-                <span class="ring middle"></span>
-                <span class="ring inner"></span>
-                <span class="dot"></span>
-            </div>
-            <div class="logo-wordmark" aria-hidden="true">
-                <span class="wordmark-primary">DAREMON</span>
-                <span class="wordmark-secondary">SOLUTIONS</span>
-            </div>
+            <article class="deadline-article" aria-labelledby="deadline-heading">
+                <h2 id="deadline-heading">Znaczenie terminu 31 marca 2026</h2>
+                <p>Termin ten, określany w Planie Socjalnym jako Faza 3, wyznacza moment przejścia zespołu Daremon do kolejnego etapu. To symboliczna granica, która podkreśla wspólne przygotowania i otwiera przestrzeń na budowanie nowych inicjatyw.</p>
+                <p>Oto dlaczego ta data inspiruje nas do działania:</p>
+                <ol>
+                    <li><strong>Pełna swoboda działania:</strong> Tego dnia wygasają formalne ograniczenia dotyczące zakazu konkurencji i pozyskiwania klientów, dzięki czemu możemy śmiało rozwijać Daremon i proponować rynkowi świeże rozwiązania.</li>
+                    <li><strong>Nowe możliwości współpracy:</strong> Po 31 marca 2026 roku kończy się zewnętrzna kontrola nad terenem i wyposażeniem, co otwiera drogę do rozmów o dalszym wykorzystaniu zasobów i wspieraniu lokalnej społeczności.</li>
+                    <li><strong>Skupienie na przyszłości:</strong> Odliczanie przypomina, że kończy się pewien etap, a przed zespołem stoją projekty, które możemy kształtować według własnych wartości i ambicji.</li>
+                </ol>
+            </article>
         </div>
         <div class="visualizer-bars" aria-hidden="true">
             <span class="bar" style="--i:0"></span>
@@ -189,7 +204,6 @@
 
                 <section id="now-playing-section" class="content-box">
                     <div class="now-playing-layout">
-                        <img id="daremon-logo" src="images/icons/logo.png" alt="Logo DAREMON Solutions" role="img" aria-label="Logo DAREMON Solutions">
                         <div id="player-ui">
                             <img id="track-cover" src="https://placehold.co/120x120/04132B/18A0C7?text=ETS" alt="Okładka aktualnego utworu">
                             <div id="track-info">
@@ -221,6 +235,127 @@
                             <input type="range" id="volume-slider" min="0" max="1" step="0.01" value="0.5" data-i18n-aria-label="volumeLabel">
                         </div>
                         <button id="tv-mode-btn" class="control-btn" data-i18n-title="fullscreenTooltip" data-i18n-aria-label="fullscreenLabel" disabled>📺</button>
+                    </div>
+                </section>
+                <section id="daremon-hub" class="content-box" aria-labelledby="daremon-hub-heading">
+                    <div class="daremon-hub-header" role="presentation">
+                        <h2 id="daremon-hub-heading">DAREMON — kontynuujemy razem</h2>
+                        <p class="daremon-hub-subtitle">Niet wraak. Voortzetting.</p>
+                        <p id="countdown-freedom-message">
+                            <span id="countdown-prep-message">Jeszcze <span data-countdown-days>0</span> dni, aby rozwinąć naszą swobodę.</span>
+                            <span id="countdown-celebration-message" hidden>Swoboda już jest z nami — korzystamy z niej razem.</span>
+                        </p>
+                    </div>
+                    <div class="daremon-tablist" role="tablist" aria-label="Sekcje planu Daremon">
+                        <button type="button" class="daremon-tab" id="daremon-tab-button-rekensom" role="tab" aria-selected="true" aria-controls="daremon-tab-rekensom">Plan na 2026</button>
+                        <button type="button" class="daremon-tab" id="daremon-tab-button-faq" role="tab" aria-selected="false" aria-controls="daremon-tab-faq" tabindex="-1">Najczęstsze pytania</button>
+                        <button type="button" class="daremon-tab" id="daremon-tab-button-training" role="tab" aria-selected="false" aria-controls="daremon-tab-training" tabindex="-1">Szkolenia</button>
+                        <button type="button" class="daremon-tab" id="daremon-tab-button-newsletter" role="tab" aria-selected="false" aria-controls="daremon-tab-newsletter" tabindex="-1">Kontakt</button>
+                    </div>
+                    <div class="daremon-tabpanels">
+                        <section id="daremon-tab-rekensom" class="daremon-tabpanel" role="tabpanel" tabindex="0" aria-labelledby="daremon-tab-button-rekensom">
+                            <div class="value-section" aria-labelledby="rekensom-heading">
+                                <h3 id="rekensom-heading">De rekensom: wspólny plan na 2026</h3>
+                                <div class="value-columns" role="list">
+                                    <article class="value-card" role="listitem" aria-labelledby="rekensom-benefits-heading">
+                                        <h4 id="rekensom-benefits-heading">Wat Rompa ons geeft</h4>
+                                        <ul>
+                                            <li>Scholingsbudget z Planu Socjalnego — inwestujemy je w strategiczne kursy.</li>
+                                            <li>Uwolnienie od non-concurrentie od 1 april 2026 — pełna legalna przestrzeń na działanie.</li>
+                                            <li>Czas do końca marca 2026 — spokój na zaplanowanie kolejnych kroków.</li>
+                                        </ul>
+                                    </article>
+                                    <article class="value-card" role="listitem" aria-labelledby="rekensom-assets-heading">
+                                        <h4 id="rekensom-assets-heading">Wat wij al hebben</h4>
+                                        <ul>
+                                            <li>200+ jaar gezamenlijke ervaring w procesach, jakości i relacjach.</li>
+                                            <li>Klantcontacten, które znają ludzi, nie tylko logo.</li>
+                                            <li>Wzajemne wsparcie — razem tworzymy zespół ekspertów.</li>
+                                        </ul>
+                                    </article>
+                                    <article class="value-card" role="listitem" aria-labelledby="rekensom-outlook-heading">
+                                        <h4 id="rekensom-outlook-heading">Wat Rompa achterlaat</h4>
+                                        <ul>
+                                            <li>Budynki Hansa i maszyny, które mogą zyskać nowe życie.</li>
+                                            <li>Popyt klientów na ciągłość produkcji.</li>
+                                            <li>Przestrzeń na Daremon — jeśli zdecydujemy się działać.</li>
+                                        </ul>
+                                    </article>
+                                </div>
+                                <p class="value-summary">Razem = większa szansa na sukces. <span class="value-highlight">Jeśli działamy wspólnie, wygrywamy doświadczeniem.</span></p>
+                            </div>
+                        </section>
+                        <section id="daremon-tab-faq" class="daremon-tabpanel" role="tabpanel" tabindex="-1" aria-labelledby="daremon-tab-button-faq" hidden>
+                            <div class="faq-section" aria-labelledby="faq-heading">
+                                <h3 id="faq-heading">De vragen die iedereen heeft</h3>
+                                <div class="faq-list" role="list">
+                                    <details class="faq-item" role="listitem">
+                                        <summary><span aria-label="Pytanie: Czy możemy legalnie konkurować?">❓ Mag ik überhaupt concurreren?</span></summary>
+                                        <p><strong>✅ Ja.</strong> Non-concurrentiebeding wygasa przy rozwiązaniu umowy — od 1 april 2026 jesteśmy wolni.</p>
+                                    </details>
+                                    <details class="faq-item" role="listitem">
+                                        <summary><span aria-label="Pytanie: Skąd wziąć środki na start?">❓ Maar ik heb geen geld om te starten...</span></summary>
+                                        <p><strong>✅ Scholingsgeld działa jak startkapitaal.</strong> Rompa finansuje kursy — wybieramy te, które przygotują nas na Daremon.</p>
+                                    </details>
+                                    <details class="faq-item" role="listitem">
+                                        <summary><span aria-label="Pytanie: Kto może dołączyć?">❓ Wie worden "wij"?</span></summary>
+                                        <p><strong>✅ Iedereen die wil.</strong> Nie ma presji, ale wspólne działanie wzmacnia wszystkich.</p>
+                                    </details>
+                                    <details class="faq-item" role="listitem">
+                                        <summary><span aria-label="Pytanie: Czy są dostępne maszyny?">❓ Kunnen we echt machines krijgen?</span></summary>
+                                        <p><strong>✅ Możemy rozmawiać.</strong> Hans posiada budynki, a maszyny mogą zostać u nas, jeśli je zabezpieczymy.</p>
+                                    </details>
+                                    <details class="faq-item" role="listitem">
+                                        <summary><span aria-label="Pytanie: Co jeśli się nie uda?">❓ Wat als het niet lukt?</span></summary>
+                                        <p><strong>✅ Próbujemy razem.</strong> Działanie daje szansę — nic nie robiąc, oddajemy tę szansę.</p>
+                                    </details>
+                                </div>
+                            </div>
+                        </section>
+                        <section id="daremon-tab-training" class="daremon-tabpanel" role="tabpanel" tabindex="-1" aria-labelledby="daremon-tab-button-training" hidden>
+                            <div class="scholings-section" aria-labelledby="scholings-heading">
+                                <h3 id="scholings-heading">Gebruik het scholingsgeld slim</h3>
+                                <p class="scholings-intro">Środki z Planu Socjalnego to inwestycja w Twoją przyszłość — wybieramy kursy, które wzmacniają Daremon.</p>
+                                <div class="scholings-grid" role="list">
+                                    <article class="scholings-card" role="listitem" aria-labelledby="scholings-production-heading">
+                                        <h4 id="scholings-production-heading">Voor productie</h4>
+                                        <ul>
+                                            <li>Geavanceerde CNC-programmering</li>
+                                            <li>MIM procesoptimalisatie</li>
+                                            <li>Systemy jakości ISO</li>
+                                        </ul>
+                                    </article>
+                                    <article class="scholings-card" role="listitem" aria-labelledby="scholings-business-heading">
+                                        <h4 id="scholings-business-heading">Voor business</h4>
+                                        <ul>
+                                            <li>Projectmanagement</li>
+                                            <li>Relacje z klientami</li>
+                                            <li>Planowanie finansowe</li>
+                                        </ul>
+                                    </article>
+                                    <article class="scholings-card" role="listitem" aria-labelledby="scholings-technical-heading">
+                                        <h4 id="scholings-technical-heading">Voor techniek</h4>
+                                        <ul>
+                                            <li>CAD/CAM &amp; nowe materiały</li>
+                                            <li>Utrzymanie ruchu</li>
+                                            <li>Diagnostyka i troubleshooting</li>
+                                        </ul>
+                                    </article>
+                                </div>
+                            </div>
+                        </section>
+                        <section id="daremon-tab-newsletter" class="daremon-tabpanel" role="tabpanel" tabindex="-1" aria-labelledby="daremon-tab-button-newsletter" hidden>
+                            <div class="newsletter-section" aria-labelledby="newsletter-heading">
+                                <h3 id="newsletter-heading">Wees op de hoogte</h3>
+                                <p>Pozostańmy w kontakcie. Wpisz adres e-mail, aby otrzymywać pozytywne aktualizacje o Daremon.</p>
+                                <form id="newsletter-form" aria-describedby="newsletter-helper">
+                                    <label for="newsletter-email">Adres e-mail</label>
+                                    <input id="newsletter-email" name="email" type="email" required aria-required="true" placeholder="naam@voorbeeld.com">
+                                    <button type="submit">Wyślij</button>
+                                    <p id="newsletter-helper">Brak zobowiązań — tylko informacje o kolejnych krokach.</p>
+                                </form>
+                            </div>
+                        </section>
                     </div>
                 </section>
                 <section id="team-moments" class="content-box photo-collage" aria-labelledby="team-moments-title">

--- a/script.js
+++ b/script.js
@@ -1,4 +1,161 @@
 // Main JavaScript file
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', () => {
     console.log('Document ready!');
-}); 
+
+    const countdownDisplay = document.getElementById('countdown-display');
+    if (!countdownDisplay) {
+        return;
+    }
+
+    const countdownElements = {
+        days: document.getElementById('countdown-days'),
+        hours: document.getElementById('countdown-hours'),
+        minutes: document.getElementById('countdown-minutes'),
+        seconds: document.getElementById('countdown-seconds')
+    };
+    const countdownStatus = document.getElementById('countdown-status');
+    const countdownFreedomMessage = document.getElementById('countdown-freedom-message');
+    const countdownPrepMessage = document.getElementById('countdown-prep-message');
+    const countdownCelebrationMessage = document.getElementById('countdown-celebration-message');
+    const countdownDayTargets = document.querySelectorAll('[data-countdown-days]');
+    const rompaDeadline = new Date(2026, 2, 31, 23, 59, 59);
+
+    const updateElementText = (element, value) => {
+        if (element) {
+            element.textContent = value;
+        }
+    };
+
+    const formatDoubleDigit = (value) => value.toString().padStart(2, '0');
+
+    let intervalId;
+
+    const updateCountdown = () => {
+        const now = new Date();
+        const diff = rompaDeadline.getTime() - now.getTime();
+        const safeDiff = Math.max(diff, 0);
+
+        const totalSeconds = Math.floor(safeDiff / 1000);
+        const days = Math.floor(totalSeconds / 86400);
+        const hours = Math.floor((totalSeconds % 86400) / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+
+        updateElementText(countdownElements.days, days.toString());
+        countdownDayTargets.forEach((element) => {
+            updateElementText(element, days.toString());
+        });
+        updateElementText(countdownElements.hours, formatDoubleDigit(hours));
+        updateElementText(countdownElements.minutes, formatDoubleDigit(minutes));
+        updateElementText(countdownElements.seconds, formatDoubleDigit(seconds));
+
+        const ariaLabel = `Pozostało ${days} dni, ${hours} godzin, ${minutes} minut i ${seconds} sekund.`;
+        countdownDisplay.setAttribute('aria-label', ariaLabel);
+
+        const celebrationMessage = '31 marca 2026 nadszedł — czas na nowy etap Daremon!';
+        const preparationMessage = `Do 31 marca 2026 pozostało ${days} dni, ${hours} godzin, ${minutes} minut i ${seconds} sekund.`;
+
+        if (countdownStatus) {
+            countdownStatus.textContent = diff <= 0 ? celebrationMessage : preparationMessage;
+        }
+
+        if (countdownFreedomMessage) {
+            const isCelebration = diff <= 0;
+
+            if (countdownPrepMessage) {
+                countdownPrepMessage.hidden = isCelebration;
+            }
+
+            if (countdownCelebrationMessage) {
+                countdownCelebrationMessage.hidden = !isCelebration;
+            }
+        }
+
+        if (diff <= 0 && intervalId) {
+            clearInterval(intervalId);
+            intervalId = null;
+        }
+    };
+
+    updateCountdown();
+    intervalId = window.setInterval(updateCountdown, 1000);
+
+    const daremonHub = document.getElementById('daremon-hub');
+
+    if (daremonHub) {
+        const tabButtons = Array.from(daremonHub.querySelectorAll('[role="tab"]'));
+        const tabPanels = Array.from(daremonHub.querySelectorAll('[role="tabpanel"]'));
+
+        const activateTab = (tab) => {
+            const targetId = tab.getAttribute('aria-controls');
+
+            tabButtons.forEach((button) => {
+                const isSelected = button === tab;
+                button.setAttribute('aria-selected', isSelected.toString());
+                button.tabIndex = isSelected ? 0 : -1;
+                button.classList.toggle('daremon-tab--active', isSelected);
+            });
+
+            tabPanels.forEach((panel) => {
+                if (panel.id === targetId) {
+                    panel.hidden = false;
+                    panel.setAttribute('tabindex', '0');
+                } else {
+                    panel.hidden = true;
+                    panel.setAttribute('tabindex', '-1');
+                }
+            });
+        };
+
+        const focusTab = (tab) => {
+            tab.focus();
+            activateTab(tab);
+        };
+
+        tabButtons.forEach((tab) => {
+            tab.addEventListener('click', () => {
+                activateTab(tab);
+            });
+
+            tab.addEventListener('keydown', (event) => {
+                const currentIndex = tabButtons.indexOf(tab);
+
+                switch (event.key) {
+                    case 'ArrowRight':
+                    case 'ArrowDown': {
+                        event.preventDefault();
+                        const nextTab = tabButtons[(currentIndex + 1) % tabButtons.length];
+                        focusTab(nextTab);
+                        break;
+                    }
+                    case 'ArrowLeft':
+                    case 'ArrowUp': {
+                        event.preventDefault();
+                        const previousIndex = (currentIndex - 1 + tabButtons.length) % tabButtons.length;
+                        const previousTab = tabButtons[previousIndex];
+                        focusTab(previousTab);
+                        break;
+                    }
+                    case 'Home': {
+                        event.preventDefault();
+                        focusTab(tabButtons[0]);
+                        break;
+                    }
+                    case 'End': {
+                        event.preventDefault();
+                        focusTab(tabButtons[tabButtons.length - 1]);
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            });
+        });
+
+        const defaultTab = tabButtons.find((button) => button.getAttribute('aria-selected') === 'true') || tabButtons[0];
+
+        if (defaultTab) {
+            activateTab(defaultTab);
+        }
+    }
+});

--- a/styles.css
+++ b/styles.css
@@ -161,167 +161,115 @@ body {
     mix-blend-mode: screen;
 }
 
-.logo-card {
+.visualizer-content {
     position: relative;
     z-index: 2;
-    padding: 56px 72px 64px;
-    border-radius: 42px;
-    background:
-        radial-gradient(circle at 20% 20%, rgba(45, 122, 201, 0.28), transparent 65%),
-        linear-gradient(160deg, rgba(3, 18, 40, 0.96), rgba(6, 31, 68, 0.98));
-    backdrop-filter: blur(16px);
-    box-shadow:
-        0 36px 120px rgba(4, 19, 43, 0.78),
-        inset 0 0 0 1px rgba(118, 205, 255, 0.1);
-    border: 1px solid rgba(36, 103, 171, 0.35);
-    isolation: isolate;
-    color: #f1f6ff;
-}
-
-.logo-card::before {
-    content: "";
-    position: absolute;
-    inset: 14px;
-    border-radius: 32px;
-    background: radial-gradient(circle at top, rgba(126, 224, 255, 0.22), transparent 70%);
-    opacity: 0.55;
-    pointer-events: none;
-}
-
-.logo-card::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: 42px;
-    box-shadow: inset 0 0 22px rgba(255, 189, 77, 0.12);
-    mix-blend-mode: screen;
-    pointer-events: none;
-}
-
-.logo-header {
     display: flex;
-    align-items: flex-end;
+    flex-direction: column;
+    align-items: center;
     gap: 28px;
+    max-width: 600px;
+}
+
+#daremon-logo {
+    width: clamp(160px, 22vw, 240px);
+    height: auto;
+    display: block;
+    filter: drop-shadow(0 0 24px rgba(126, 224, 255, 0.45));
+}
+
+.countdown-card {
+    width: 100%;
+    padding: 24px 28px;
+    border-radius: 28px;
+    background:
+        linear-gradient(180deg, rgba(9, 28, 54, 0.92), rgba(4, 12, 28, 0.92));
+    border: 1px solid rgba(126, 224, 255, 0.26);
+    box-shadow:
+        0 30px 50px rgba(2, 9, 24, 0.6),
+        inset 0 0 0 1px rgba(126, 224, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    color: #eaf9ff;
+}
+
+#countdown-heading {
+    margin: 0;
+    font-size: clamp(1.1rem, 3vw, 1.6rem);
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+#countdown-display {
+    display: flex;
+    gap: clamp(12px, 2vw, 20px);
     justify-content: center;
 }
 
-.logo-ib {
-    font-size: clamp(4.5rem, 10vw, 5.4rem);
-    font-weight: 700;
-    letter-spacing: -6px;
-    text-transform: lowercase;
-    color: #ecf3ff;
-    text-shadow:
-        0 0 12px rgba(126, 224, 255, 0.55),
-        0 0 42px rgba(126, 224, 255, 0.35);
-}
-
-.logo-ib span {
-    display: inline-block;
-    color: #ffffff;
-    font-weight: 800;
-    transform: translateX(-10px);
-    text-shadow: 0 0 16px rgba(255, 255, 255, 0.65);
-}
-
-.logo-tagline {
-    display: grid;
-    text-transform: uppercase;
-    font-size: clamp(0.95rem, 2.2vw, 1.15rem);
-    row-gap: 2px;
-    letter-spacing: 0.3em;
-    text-align: left;
-    color: rgba(155, 214, 255, 0.85);
-}
-
-.logo-in {
-    color: #9bd6ff;
-}
-
-.logo-team {
-    color: #7ee0ff;
-    font-weight: 600;
-}
-
-.logo-betrouwbaar {
-    color: #d4e8ff;
-    font-weight: 300;
-    letter-spacing: 0.24em;
-}
-
-.logo-emblem {
-    position: relative;
-    width: 220px;
-    height: 220px;
-    margin: 36px auto 28px;
-    filter: drop-shadow(0 0 22px rgba(126, 224, 255, 0.35));
-}
-
-.logo-emblem .ring {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    border-radius: 50%;
-    border: 6px solid transparent;
-    background: conic-gradient(from 90deg, rgba(0, 174, 239, 0.9), rgba(4, 19, 43, 0.35), rgba(0, 174, 239, 0.9)) border-box;
-    mask: radial-gradient(circle, transparent 63%, black 64%);
-}
-
-.logo-emblem .ring.outer {
-    width: 220px;
-    height: 220px;
-    border-width: 8px;
-}
-
-.logo-emblem .ring.middle {
-    width: 150px;
-    height: 150px;
-    border-width: 10px;
-    mask: radial-gradient(circle, transparent 54%, black 55%);
-}
-
-.logo-emblem .ring.inner {
-    width: 92px;
-    height: 92px;
-    border-width: 12px;
-    mask: radial-gradient(circle, transparent 37%, black 38%);
-}
-
-.logo-emblem .dot {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 26px;
-    height: 26px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #7ee0ff, #18a0c7);
-    box-shadow:
-        0 0 18px rgba(126, 224, 255, 0.9),
-        0 0 38px rgba(126, 224, 255, 0.6);
-}
-
-.logo-wordmark {
+.countdown-part {
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 6px;
-    letter-spacing: 0.35em;
+    min-width: 70px;
 }
 
-.wordmark-primary {
-    font-size: clamp(1.6rem, 5vw, 2.2rem);
+.countdown-value {
+    font-size: clamp(1.8rem, 5vw, 2.6rem);
     font-weight: 800;
-    color: #eaf3ff;
-    text-shadow: 0 0 16px rgba(126, 224, 255, 0.35);
+    color: var(--primary-accent);
+    text-shadow: 0 0 16px rgba(126, 224, 255, 0.65);
 }
 
-.wordmark-secondary {
-    font-size: clamp(0.75rem, 2.5vw, 1rem);
-    font-weight: 500;
-    color: rgba(155, 214, 255, 0.78);
-    letter-spacing: 0.48em;
-    text-shadow: 0 0 14px rgba(126, 224, 255, 0.28);
+.countdown-unit {
+    font-size: 0.9rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(234, 249, 255, 0.75);
+}
+
+#countdown-status {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(234, 249, 255, 0.85);
+    text-align: center;
+}
+
+.deadline-article {
+    width: 100%;
+    padding: 26px 30px;
+    border-radius: 28px;
+    background: rgba(6, 18, 40, 0.82);
+    border: 1px solid rgba(24, 160, 199, 0.2);
+    box-shadow: 0 20px 45px rgba(2, 9, 24, 0.6);
+    color: #f1fbff;
+    text-align: left;
+}
+
+.deadline-article h2 {
+    margin-top: 0;
+    font-size: clamp(1.3rem, 4vw, 2rem);
+    color: var(--primary-accent);
+}
+
+.deadline-article p {
+    margin: 0 0 0.8rem 0;
+    line-height: 1.7;
+}
+
+.deadline-article ol {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.deadline-article li {
+    line-height: 1.6;
 }
 
 .visualizer-bars {
@@ -464,18 +412,11 @@ body {
 }
 
 .now-playing-layout {
-    display: grid;
-    grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
-    align-items: center;
-    gap: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
     width: 100%;
-}
-
-#daremon-logo {
-    width: clamp(120px, 18vw, 200px);
-    height: auto;
-    justify-self: center;
-    display: block;
 }
 
 #player-ui {
@@ -1005,14 +946,263 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
 .disclaimer-text { font-size: 0.7em; opacity: 0.6; text-align: center; margin-top: 10px; }
 .disclaimer-highlight { color: var(--secondary-accent); font-weight: bold; }
 
+/* --- Daremon Hub Tabs --- */
+#daremon-hub {
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto 80px;
+    display: flex;
+    flex-direction: column;
+    gap: 48px;
+    align-items: stretch;
+}
+
+.daremon-hub-header {
+    padding: 36px 42px;
+    border-radius: 32px;
+    background: linear-gradient(135deg, rgba(24, 160, 199, 0.18), rgba(9, 28, 54, 0.78));
+    border: 1px solid rgba(155, 214, 255, 0.28);
+    text-align: center;
+    box-shadow: 0 30px 60px rgba(2, 9, 24, 0.45);
+}
+
+.daremon-hub-header h2 {
+    margin: 0 0 8px;
+    font-size: clamp(1.6rem, 4vw, 2.2rem);
+    letter-spacing: 0.06em;
+}
+
+.daremon-hub-subtitle {
+    margin: 0 0 12px;
+    font-size: clamp(1rem, 3vw, 1.2rem);
+    color: var(--secondary-accent);
+}
+
+#countdown-freedom-message {
+    margin: 0;
+    font-size: clamp(1rem, 3vw, 1.3rem);
+    color: #eaf9ff;
+}
+
+#countdown-freedom-message span[hidden] {
+    display: none;
+}
+
+.value-section,
+.faq-section,
+.scholings-section,
+.newsletter-section {
+    padding: 32px 38px;
+    border-radius: 28px;
+    background: rgba(4, 19, 43, 0.72);
+    border: 1px solid rgba(24, 160, 199, 0.22);
+    box-shadow: 0 24px 45px rgba(2, 9, 24, 0.4);
+}
+
+.daremon-tablist {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+}
+
+.daremon-tab {
+    background: rgba(9, 28, 54, 0.72);
+    border: 1px solid rgba(24, 160, 199, 0.32);
+    color: #eaf9ff;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 10px 18px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.daremon-tab:focus-visible {
+    outline: 2px solid var(--secondary-accent);
+    outline-offset: 3px;
+}
+
+.daremon-tab--active,
+.daremon-tab[aria-selected="true"] {
+    background: rgba(24, 160, 199, 0.25);
+    border-color: rgba(155, 214, 255, 0.8);
+    color: #fff;
+}
+
+.daremon-tabpanel {
+    margin-top: 8px;
+}
+
+.value-section h3,
+.faq-section h3,
+.scholings-section h3,
+.newsletter-section h3 {
+    margin-top: 0;
+    margin-bottom: 18px;
+    font-size: clamp(1.3rem, 3vw, 1.7rem);
+}
+
+.value-columns {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 20px;
+    margin-bottom: 18px;
+}
+
+.value-card {
+    padding: 20px;
+    border-radius: 22px;
+    background: rgba(12, 36, 72, 0.72);
+    border: 1px solid rgba(155, 214, 255, 0.16);
+    box-shadow: inset 0 0 0 1px rgba(24, 160, 199, 0.08);
+}
+
+.value-card h4 {
+    margin-top: 0;
+    margin-bottom: 12px;
+    color: var(--secondary-accent);
+    font-size: 1.05rem;
+}
+
+.value-card ul {
+    margin: 0;
+    padding-left: 18px;
+    line-height: 1.6;
+}
+
+.value-summary {
+    margin: 0;
+    font-size: 1rem;
+    text-align: center;
+}
+
+.value-highlight {
+    color: var(--secondary-accent);
+    font-weight: 700;
+}
+
+.faq-list {
+    display: grid;
+    gap: 16px;
+}
+
+.faq-item {
+    border-radius: 18px;
+    background: rgba(12, 36, 72, 0.65);
+    border: 1px solid rgba(24, 160, 199, 0.16);
+    padding: 16px 20px;
+    transition: background 0.3s ease;
+}
+
+.faq-item[open] {
+    background: rgba(24, 160, 199, 0.12);
+}
+
+.faq-item summary {
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 1rem;
+    list-style: none;
+}
+
+.faq-item summary::-webkit-details-marker {
+    display: none;
+}
+
+.faq-item p {
+    margin: 12px 0 0;
+    line-height: 1.6;
+}
+
+.scholings-intro {
+    margin-top: 0;
+    margin-bottom: 18px;
+    line-height: 1.6;
+}
+
+.scholings-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 20px;
+}
+
+.scholings-card {
+    padding: 20px;
+    border-radius: 20px;
+    background: rgba(12, 36, 72, 0.68);
+    border: 1px solid rgba(155, 214, 255, 0.16);
+    box-shadow: inset 0 0 0 1px rgba(24, 160, 199, 0.08);
+}
+
+.scholings-card h4 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    color: var(--secondary-accent);
+}
+
+.scholings-card ul {
+    margin: 0;
+    padding-left: 18px;
+    line-height: 1.6;
+}
+
+.newsletter-section form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.newsletter-section label {
+    font-weight: 600;
+}
+
+.newsletter-section input {
+    padding: 12px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(155, 214, 255, 0.28);
+    background: rgba(12, 36, 72, 0.5);
+    color: var(--text-color);
+    font-family: var(--font-family);
+}
+
+.newsletter-section input:focus {
+    outline: none;
+    border-color: var(--secondary-accent);
+    box-shadow: 0 0 0 3px rgba(155, 214, 255, 0.25);
+}
+
+.newsletter-section button {
+    align-self: flex-start;
+    padding: 10px 28px;
+    border-radius: 999px;
+    border: none;
+    cursor: pointer;
+    font-family: var(--font-family);
+    font-weight: 700;
+    background: var(--secondary-accent);
+    color: #04132b;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.newsletter-section button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 0 18px rgba(155, 214, 255, 0.35);
+}
+
+.newsletter-section p {
+    margin: 0;
+    line-height: 1.6;
+}
+
 /* --- Responsiviteit --- */
 @media (max-width: 900px) {
     body { padding: 10px; padding-bottom: 80px; }
     #visualizer-showcase { min-height: 480px; padding: 110px 48px 150px; margin: 30px auto 50px; border-radius: 40px; }
-    .logo-card { padding: 44px 36px 52px; border-radius: 34px; }
-    .logo-header { flex-direction: column; gap: 16px; align-items: center; }
-    .logo-tagline { text-align: center; letter-spacing: 0.22em; }
-    .logo-emblem { transform: scale(0.85); margin: 22px auto; }
+    .visualizer-content { gap: 24px; }
+    .countdown-card { padding: 22px; }
+    #countdown-display { flex-wrap: wrap; }
+    .deadline-article { padding: 22px 24px; }
     .visualizer-bars { height: 150px; gap: 4px; padding: 0 16px; bottom: 26px; }
     .bar { width: 10px; }
     #app-container { flex-direction: column; }
@@ -1020,13 +1210,8 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
     #radio-view { flex-direction: column; }
 
     .now-playing-layout {
-        grid-template-columns: 1fr;
-        justify-items: center;
-        gap: 1.5rem;
-    }
-
-    #daremon-logo {
-        margin: 0;
+        align-items: center;
+        text-align: center;
     }
 
     #side-panel {
@@ -1050,6 +1235,16 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
     #track-cover { width: 150px; height: 150px; }
     .video-grid { grid-template-columns: 1fr; }
 
+    #daremon-hub {
+        margin-bottom: 60px;
+        gap: 32px;
+    }
+
+    .value-columns,
+    .scholings-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
     #menu-toggle {
         display: flex; 
         justify-content: center; 
@@ -1071,15 +1266,36 @@ body, #app-container, #main-content, #player-ui, #player-controls, #side-panel {
 
 @media (max-width: 600px) {
     #visualizer-showcase { min-height: 420px; padding: 90px 28px 140px; border-radius: 32px; }
-    .logo-card { padding: 34px 22px 40px; border-radius: 26px; }
-    .logo-ib { font-size: 3.7rem; letter-spacing: -4px; }
-    .logo-tagline { font-size: 0.9rem; letter-spacing: 0.18em; }
-    .logo-emblem { transform: scale(0.7); }
-    .wordmark-primary { font-size: 1.35rem; }
-    .wordmark-secondary { font-size: 0.65rem; letter-spacing: 0.32em; }
+    .visualizer-content { gap: 20px; }
+    #daremon-logo { width: clamp(140px, 40vw, 200px); }
+    .countdown-card { padding: 18px; }
+    #countdown-display { gap: 10px; }
+    .countdown-part { min-width: 60px; }
+    .deadline-article { padding: 18px 20px; }
     .visualizer-bars { height: 130px; bottom: 20px; }
     .bar { width: 9px; }
     .photo-gallery-grid { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
     .photo-collage-grid { grid-template-columns: 1fr; }
     .video-card figcaption { text-align: center; }
+
+    #daremon-hub {
+        padding: 0 6px;
+        gap: 28px;
+    }
+
+    .value-section,
+    .faq-section,
+    .scholings-section,
+    .newsletter-section {
+        padding: 24px;
+    }
+
+    .value-columns,
+    .scholings-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .newsletter-section button {
+        align-self: stretch;
+    }
 }

--- a/tests/now-playing-layout.test.js
+++ b/tests/now-playing-layout.test.js
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 const html = readFileSync(resolve(__dirname, '../index.html'), 'utf-8');
 
 describe('now playing layout', () => {
-  it('keeps the Daremon logo centered inside the player layout container', () => {
+  it('renders the player UI without the Daremon logo inside the layout grid', () => {
     expect(html).toContain('class="now-playing-layout"');
 
     const sectionMatch = html.match(
@@ -16,7 +16,37 @@ describe('now playing layout', () => {
     );
 
     expect(sectionMatch).toBeTruthy();
-    expect(sectionMatch?.[1]).toContain('<img id="daremon-logo"');
+    expect(sectionMatch?.[1]).not.toContain('<img id="daremon-logo"');
     expect(sectionMatch?.[1]).toContain('<div id="player-ui">');
+  });
+
+  it('positions the Daremon logo and countdown inside the visualizer showcase', () => {
+    const visualizerMatch = html.match(
+      /<section id="visualizer-showcase"[\s\S]*?<\/section>/
+    );
+
+    expect(visualizerMatch).toBeTruthy();
+    expect(visualizerMatch?.[0]).toContain('<img id="daremon-logo"');
+    expect(visualizerMatch?.[0]).toContain('id="countdown-display"');
+  });
+
+  it('moves the Daremon invitation content into tabs placed under the player', () => {
+    const mainMatch = html.match(
+      /<main id="main-content">([\s\S]*?)<\/main>/
+    );
+
+    expect(mainMatch).toBeTruthy();
+
+    const mainContent = mainMatch?.[1] ?? '';
+    const nowPlayingIndex = mainContent.indexOf('id="now-playing-section"');
+    const hubIndex = mainContent.indexOf('id="daremon-hub"');
+
+    expect(nowPlayingIndex).toBeGreaterThanOrEqual(0);
+    expect(hubIndex).toBeGreaterThan(nowPlayingIndex);
+    expect(mainContent).toContain('role="tablist"');
+    expect(mainContent).toContain('role="tabpanel"');
+
+    const hiddenPanelMatch = mainContent.match(/role="tabpanel"[\s\S]*?hidden/);
+    expect(hiddenPanelMatch).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- introduce a Daremon invitation section with uplifting countdown messaging and banner content
- add Rekensom, FAQ, training, and newsletter subsections that highlight collaborative opportunities
- extend countdown scripting and styling to support the new positive sections and responsive layout
- hide the Daremon invitation content inside accessible tabs beneath the player interface

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e43854ea3c8322ad709090b7fce4b3