### PR TITLE
Fix metadata quotes in diensten page

### DIFF
--- a/app/diensten/page.tsx
+++ b/app/diensten/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Hypothetische scenario's – Daremon',
-  description: 'Fictieve scenario's gegenereerd door AI: technische systemen, instituties, narratieven en analyses. Geen echte diensten.',
+  title: "Hypothetische scenario's – Daremon",
+  description: "Fictieve scenario's gegenereerd door AI: technische systemen, instituties, narratieven en analyses. Geen echte diensten.",
 }
 
 export default function DienstenPage() {

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from 'react'
 
 const navItems = [
   { href: '/', label: 'Start' },
-  { href: '/diensten', label: 'Scenario's' },
+  { href: '/diensten', label: "Scenario's" },
   { href: '/casussen', label: 'Verhalen' },
   { href: '/methodiek', label: 'Methodiek & AI' },
   { href: '/over', label: 'Over het project' },


### PR DESCRIPTION
Changed string delimiters from single to double quotes in metadata and navigation labels containing "scenario's" to prevent syntax conflicts.

Files updated:
- app/diensten/page.tsx (metadata title & description)
- components/navigation.tsx (navigation label)