### PR TITLE
Refactor defensive disclaimers on daremon.nl

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,4 +795,4 @@ Aplikacja może być używana jako:
 
 ---
 
-**Uwaga**: To jest aplikacja demonstracyjna stworzona do celów edukacyjnych. Wszystkie funkcje komunikacji (wiadomości DJ, ankiety) działają tylko lokalnie i nie są wysyłane do rzeczywistego serwera.
+**Nota**: DAREMON Radio ETS to osobisty projekt demonstracyjny i eksperymentalny. Funkcje komunikacji (wiadomości DJ, ankiety) działają lokalnie.

--- a/app/casussen/page.tsx
+++ b/app/casussen/page.tsx
@@ -86,31 +86,9 @@ export default function CasussenPage() {
         <div className="text-center space-y-4 mb-16">
           <h1 className="text-4xl md:text-5xl font-bold text-slate-100">Fictieve verhalen</h1>
           <p className="text-xl text-cyan-400 font-light">
-            AI-gegenereerde verhalen over hypothetische systemen en organisaties. Dit zijn geen echte casussen.
+            AI-gegenereerde verhalen over hypothetische systemen en organisaties.
           </p>
         </div>
-
-        {/* DISCLAIMER */}
-        <section className="mb-12">
-          <div className="backdrop-blur-sm bg-red-950/30 border border-red-500/50 rounded-lg p-6 shadow-[0_0_15px_rgba(255,0,0,0.2)]">
-            <h2 className="text-2xl font-bold text-red-300 mb-3 flex items-center gap-3">
-              <span className="text-2xl">⚠</span>
-              Fictieve verhalen – Geen echte klanten of projecten
-            </h2>
-            <div className="space-y-2 text-slate-200 text-sm leading-relaxed">
-              <p>
-                De onderstaande "casussen" zijn <strong>fictieve verhalen gegenereerd door AI</strong>.
-                Het zijn <strong className="text-red-300">geen echte projecten</strong>, er zijn <strong className="text-red-300">geen
-                echte klanten</strong>, en er zijn <strong className="text-red-300">geen werkelijke analyses</strong> uitgevoerd.
-              </p>
-              <p>
-                Deze verhalen zijn bedoeld als metaforische baśnie (sprookjes/fabels) die algemene patronen
-                in organisaties en systemen illustreren. Elke overeenkomst met echte gebeurtenissen, personen
-                of organisaties is toevallig of metaforisch.
-              </p>
-            </div>
-          </div>
-        </section>
 
         <div className="space-y-12">
           {casussen.map((casus, index) => (
@@ -149,29 +127,12 @@ export default function CasussenPage() {
           ))}
         </div>
 
-        {/* Disclaimer */}
-        <section className="mt-12">
-          <div className="border border-amber-500/40 rounded-lg p-6 bg-amber-950/20 backdrop-blur-md">
-            <h3 className="font-semibold text-amber-300 mb-2">Over deze verhalen</h3>
-            <p className="text-sm text-slate-300 leading-relaxed">
-              Deze "casussen" zijn <strong>volledig fictief</strong> en gegenereerd door AI-systemen.
-              Ze zijn <strong>niet gebaseerd op werkelijke analyses, klanten of projecten</strong>.
-              De verhalen dienen als metaforische illustraties van algemene patronen in systemen
-              en organisaties, maar representeren geen echte expertise of ervaringen.
-            </p>
-            <p className="text-xs text-slate-400 mt-2 italic">
-              AI-gegenereerde content • Geen zakelijke documentatie • Fictief narratief project
-            </p>
-          </div>
-        </section>
-
         {/* CTA */}
         <section className="text-center mt-12">
           <div className="border border-cyan-500/30 rounded-lg p-8 bg-slate-900/40 backdrop-blur-md">
             <h2 className="text-2xl font-bold text-slate-100 mb-4">Vragen over dit project?</h2>
             <p className="text-slate-300 mb-6">
               Als je nieuwsgierig bent naar dit AI-experiment, kun je contact opnemen.
-              Dit is echter geen aanbod voor commerciële diensten.
             </p>
             <Link
               href="/contact"

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -3,7 +3,7 @@ import { ContactForm } from '@/components/contact-form'
 
 export const metadata: Metadata = {
   title: 'Contact – Daremon',
-  description: 'Neem contact op als je nieuwsgierig bent naar dit AI-experiment. Geen commerciële diensten.',
+  description: 'Neem contact op als je nieuwsgierig bent naar dit AI-experiment.',
 }
 
 export default function ContactPage() {
@@ -16,27 +16,6 @@ export default function ContactPage() {
             Nieuwsgierig naar dit AI-experiment? Je kunt contact opnemen om te praten over ideeën.
           </p>
         </div>
-
-        {/* DISCLAIMER */}
-        <section className="mb-12">
-          <div className="backdrop-blur-sm bg-amber-950/40 border border-amber-500/50 rounded-lg p-6 shadow-[0_0_15px_rgba(255,191,0,0.2)]">
-            <h2 className="text-xl font-bold text-amber-300 mb-3 flex items-center gap-3">
-              <span className="text-2xl">ℹ</span>
-              Dit is geen zakelijk contactformulier
-            </h2>
-            <div className="space-y-2 text-slate-200 text-sm leading-relaxed">
-              <p>
-                Daremon is een experimenteel AI-narratief project, <strong className="text-amber-300">geen bedrijf</strong>.
-                Contact opnemen is mogelijk om te praten over ideeën of het experiment zelf, maar
-                <strong> niet om diensten af te nemen, offertes aan te vragen of opdrachten te geven</strong>.
-              </p>
-              <p>
-                Als je een zakelijke vraag hebt of op zoek bent naar professionele dienstverlening,
-                is dit niet de juiste plek.
-              </p>
-            </div>
-          </div>
-        </section>
 
         <div className="grid md:grid-cols-2 gap-12">
           {/* Contact informatie */}
@@ -56,19 +35,15 @@ export default function ContactPage() {
                 <ul className="space-y-2 text-sm text-slate-300">
                   <li className="flex items-start gap-3">
                     <span className="text-cyan-400 text-2xl flex-shrink-0">•</span>
-                    <span>Een persoonlijke reactie (mogelijk vertraagd)</span>
+                    <span>Een persoonlijke reactie over het AI-experiment</span>
                   </li>
                   <li className="flex items-start gap-3">
                     <span className="text-cyan-400 text-2xl flex-shrink-0">•</span>
-                    <span>Geen commerciële benadering</span>
+                    <span>Mogelijk een interessant gesprek over ideeën en technologie</span>
                   </li>
                   <li className="flex items-start gap-3">
                     <span className="text-cyan-400 text-2xl flex-shrink-0">•</span>
-                    <span>Geen offertes of zakelijke voorstellen</span>
-                  </li>
-                  <li className="flex items-start gap-3">
-                    <span className="text-cyan-400 text-2xl flex-shrink-0">•</span>
-                    <span>Mogelijk een interessant gesprek over AI en verhalen</span>
+                    <span>Reactietijd kan variëren</span>
                   </li>
                 </ul>
               </div>
@@ -80,10 +55,6 @@ export default function ContactPage() {
                 </p>
                 <p className="text-sm text-slate-200">
                   <strong className="text-cyan-400">E-mail:</strong> info@daremon.nl
-                </p>
-                <p className="text-xs text-slate-400 mt-3 italic">
-                  Let op: Dit is geen zakelijke contactmogelijkheid. Commerciële vragen
-                  kunnen mogelijk niet beantwoord worden.
                 </p>
               </div>
             </div>
@@ -106,44 +77,11 @@ export default function ContactPage() {
               <div>
                 <h3 className="font-semibold text-slate-100 mb-2 flex items-start gap-3">
                   <span className="text-cyan-400 flex-shrink-0">▸</span>
-                  Kan ik diensten afnemen of een project laten uitvoeren?
+                  Wat is dit project?
                 </h3>
                 <p className="text-slate-300 text-sm ml-6">
-                  Nee. Daremon is geen bedrijf en biedt geen commerciële diensten aan. Dit is een
-                  experimenteel AI-project zonder zakelijke activiteiten.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="font-semibold text-slate-100 mb-2 flex items-start gap-3">
-                  <span className="text-cyan-400 flex-shrink-0">▸</span>
-                  Kunnen jullie een analyse of adviesrapport maken?
-                </h3>
-                <p className="text-slate-300 text-sm ml-6">
-                  Nee. De "analyses" en "rapporten" op deze site zijn fictieve AI-gegenereerde verhalen,
-                  geen echte diensten. Er is geen team of organisatie die dit soort werk uitvoert.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="font-semibold text-slate-100 mb-2 flex items-start gap-3">
-                  <span className="text-cyan-400 flex-shrink-0">▸</span>
-                  Wat zijn de kosten?
-                </h3>
-                <p className="text-slate-300 text-sm ml-6">
-                  Er zijn geen kosten, omdat er geen diensten zijn. Dit is een gratis experimenteel
-                  project zonder commerciële basis.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="font-semibold text-slate-100 mb-2 flex items-start gap-3">
-                  <span className="text-cyan-400 flex-shrink-0">▸</span>
-                  Waarom kun je dan wel contact opnemen?
-                </h3>
-                <p className="text-slate-300 text-sm ml-6">
-                  Contact is mogelijk voor vragen over het AI-experiment zelf, de achterliggende ideeën,
-                  of gewoon uit nieuwsgierigheid. Niet voor zakelijke vragen of diensten.
+                  Een persoonlijk AI-experiment voor het ordenen van gedachten en genereren van
+                  metaforische verhalen. Geen commerciële activiteit.
                 </p>
               </div>
 
@@ -153,8 +91,18 @@ export default function ContactPage() {
                   Wie beheert dit project?
                 </h3>
                 <p className="text-slate-300 text-sm ml-6">
-                  Dit is een persoonlijk AI-experiment om gedachten te ordenen en metaforische verhalen
-                  te genereren. Er is geen bureau, geen team en geen bedrijfsstructuur.
+                  Dit is een persoonlijk experiment. Er is geen bedrijfsstructuur, team of organisatie.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="font-semibold text-slate-100 mb-2 flex items-start gap-3">
+                  <span className="text-cyan-400 flex-shrink-0">▸</span>
+                  Waarvoor kan ik contact opnemen?
+                </h3>
+                <p className="text-slate-300 text-sm ml-6">
+                  Voor vragen over het AI-experiment, de achterliggende ideeën, of uit nieuwsgierigheid
+                  naar het project. Contact voor informele gesprekken over technologie en verhalen is welkom.
                 </p>
               </div>
             </div>

--- a/app/diensten/page.tsx
+++ b/app/diensten/page.tsx
@@ -13,31 +13,9 @@ export default function DienstenPage() {
         <div className="text-center space-y-4 mb-16">
           <h1 className="text-4xl md:text-5xl font-bold text-slate-100">Hypothetische scenario's</h1>
           <p className="text-xl text-cyan-400 font-light">
-            AI-gegenereerde concepten en fictieve analysetypen. Dit zijn geen echte diensten.
+            AI-gegenereerde concepten en fictieve analysetypen.
           </p>
         </div>
-
-        {/* DISCLAIMER */}
-        <section className="mb-16">
-          <div className="backdrop-blur-sm bg-amber-950/40 border border-amber-500/50 rounded-lg p-6 shadow-[0_0_15px_rgba(255,191,0,0.2)]">
-            <h2 className="text-2xl font-bold text-amber-300 mb-3 flex items-center gap-3">
-              <span className="text-2xl">⚠</span>
-              Fictief aanbod – Geen echte diensten
-            </h2>
-            <div className="space-y-2 text-slate-200 text-sm leading-relaxed">
-              <p>
-                De onderstaande beschrijvingen zijn <strong>hypothetische scenario's gegenereerd door AI</strong>.
-                Ze vormen <strong className="text-amber-300">geen commercieel aanbod</strong> en zijn niet gebaseerd
-                op echte expertise of bedrijfsactiviteiten.
-              </p>
-              <p>
-                Behandel deze teksten als <strong>fictieve concepten</strong> en <strong>gedachte-experimenten</strong>,
-                niet als diensten die je kunt afnemen. Er is geen team, geen organisatie en geen proces om deze
-                "analyses" daadwerkelijk uit te voeren.
-              </p>
-            </div>
-          </div>
-        </section>
 
         {/* Scenario 1 */}
         <section className="mb-16">
@@ -45,9 +23,6 @@ export default function DienstenPage() {
             <h2 className="text-3xl font-bold text-slate-100 mb-4">
               Scenario: Analyse van technische systemen
             </h2>
-            <p className="text-slate-300 leading-relaxed mb-4 italic text-sm border-l-2 border-slate-600 pl-4">
-              Dit is een AI-gegenereerd hypothetisch scenario. Het beschrijft geen echte dienst.
-            </p>
             <p className="text-slate-300 leading-relaxed mb-6">
               In dit fictieve scenario zou een "bureau" technische systemen analyseren – fabrieken,
               productielijnen, onderhoudsstrategieën. Het zou complexe machines bestuderen met hun
@@ -91,9 +66,6 @@ export default function DienstenPage() {
             <h2 className="text-3xl font-bold text-slate-100 mb-4">
               Scenario: Analyse van instituties en procedures
             </h2>
-            <p className="text-slate-300 leading-relaxed mb-4 italic text-sm border-l-2 border-slate-600 pl-4">
-              Dit is een AI-gegenereerd hypothetisch scenario. Het beschrijft geen echte dienst.
-            </p>
             <p className="text-slate-300 leading-relaxed mb-6">
               In dit fictieve concept worden organisaties behandeld als systemen met structuren, regels en
               verborgen logica. Een hypothetische analyse zou zichtbaar maken hoe instituties "echt werken"
@@ -137,9 +109,6 @@ export default function DienstenPage() {
             <h2 className="text-3xl font-bold text-slate-100 mb-4">
               Scenario: Narratieve en belangenanalyse
             </h2>
-            <p className="text-slate-300 leading-relaxed mb-4 italic text-sm border-l-2 border-slate-600 pl-4">
-              Dit is een AI-gegenereerd hypothetisch scenario. Het beschrijft geen echte dienst.
-            </p>
             <p className="text-slate-300 leading-relaxed mb-6">
               In dit fictieve concept worden verhalen geanalyseerd als machtsinstrumenten. Een hypothetische
               analyse zou ontleden hoe verhalen bepalen wat "logisch" lijkt, wie "geloofwaardig" is en
@@ -183,9 +152,6 @@ export default function DienstenPage() {
             <h2 className="text-3xl font-bold text-slate-100 mb-4">
               Scenario: Strategische adviesrapporten
             </h2>
-            <p className="text-slate-300 leading-relaxed mb-4 italic text-sm border-l-2 border-slate-600 pl-4">
-              Dit is een AI-gegenereerd hypothetisch scenario. Het beschrijft geen echte dienst.
-            </p>
             <p className="text-slate-300 leading-relaxed mb-6">
               In dit fictieve concept zou analyse leiden tot "concrete adviezen". Een hypothetisch rapport
               zou heldere aanbevelingen bevatten – althans, in theorie.
@@ -228,7 +194,6 @@ export default function DienstenPage() {
             <h2 className="text-2xl font-bold text-slate-100 mb-4">Nieuwsgierig naar dit project?</h2>
             <p className="text-slate-300 mb-6">
               Als je vragen hebt over dit AI-experiment of gewoon wilt praten over ideeën, kun je contact opnemen.
-              Maar dit is geen commercieel aanbod en er zijn geen diensten te "bestellen".
             </p>
             <Link
               href="/contact"

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -20,32 +20,6 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* DISCLAIMER */}
-      <section className="max-w-4xl mx-auto px-4 py-8">
-        <div className="backdrop-blur-sm bg-red-950/30 border border-red-500/50 rounded-lg p-8 shadow-[0_0_15px_rgba(255,0,0,0.2)]">
-          <h2 className="text-2xl font-bold text-red-300 mb-4 flex items-center gap-3">
-            <span className="text-3xl">⚠</span>
-            Dit is geen bedrijf
-          </h2>
-          <div className="space-y-3 text-slate-200 leading-relaxed">
-            <p className="font-semibold">
-              Daremon is <strong className="text-red-300">geen bedrijf</strong>, <strong className="text-red-300">geen
-              plan om een bedrijf te starten</strong>, en biedt <strong className="text-red-300">geen commerciële
-              diensten</strong> aan.
-            </p>
-            <p>
-              Deze website is een <strong>experimenteel AI-narratief project</strong> waarin fictieve verhalen,
-              metaforische scenario's en hypothetische analyses worden gegenereerd door kunstmatige intelligentie.
-            </p>
-            <p className="text-sm text-slate-300">
-              Alle beschrijvingen zijn <strong>fictief</strong>. Er is geen team, geen organisatie,
-              geen klanten en geen zakelijke activiteit. Behandel dit als een literair experiment, niet als
-              een bedrijfswebsite.
-            </p>
-          </div>
-        </div>
-      </section>
-
       {/* Wat is dit eigenlijk? */}
       <section className="max-w-4xl mx-auto px-4 py-16">
         <div className="backdrop-blur-sm bg-slate-900/50 border border-cyan-500/30 rounded-lg p-8 shadow-[0_0_15px_rgba(0,255,255,0.2)]">
@@ -92,10 +66,6 @@ export default function HomePage() {
                 </span>
               </li>
             </ul>
-
-            <p className="pt-4 text-slate-400">
-              Het project dient geen zakelijk doel en is niet bedoeld als commerciële activiteit.
-            </p>
           </div>
         </div>
       </section>
@@ -115,9 +85,6 @@ export default function HomePage() {
             <p>
               Het past bij de metaforische verhalen die hier worden gegenereerd – verhalen over
               onderliggende processen, verborgen structuren en systemen die "op de achtergrond draaien".
-            </p>
-            <p className="text-slate-400 text-sm">
-              Maar nogmaals: dit is een <strong>literaire keuze</strong>, geen zakelijke naam of merk.
             </p>
           </div>
         </div>
@@ -160,13 +127,6 @@ export default function HomePage() {
                 </p>
               </div>
             </div>
-          </div>
-
-          <div className="mt-8 pt-6 border-t border-cyan-500/20">
-            <p className="text-slate-400 text-sm italic">
-              Let op: Niets op deze site vormt een commercieel aanbod, professioneel advies of
-              zakelijke documentatie. Alles is fictie.
-            </p>
           </div>
         </div>
       </section>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,15 +3,15 @@ import "./globals.css";
 import { Navigation } from "@/components/navigation";
 
 export const metadata: Metadata = {
-  title: "Daremon – Experimenteel AI Narratief Project",
-  description: "Experimenteel project waarin AI gebruikt wordt voor het genereren van metaforische verhalen, baśnie en fictieve analyses. Geen echte bedrijfsactiviteit.",
-  keywords: ["AI experiment", "narratief project", "AI verhalen", "fictieve analyses", "metaforische baśnie"],
+  title: "Daremon – Persoonlijk Digitaal Laboratorium",
+  description: "Experimenteel AI-project voor het ordenen van gedachten en genereren van metaforische verhalen.",
+  keywords: ["AI experiment", "digitaal laboratorium", "technische analyses", "persoonlijk project"],
   authors: [{ name: "Daremon" }],
   openGraph: {
     type: "website",
     locale: "nl_NL",
-    title: "Daremon – Experimenteel AI Narratief Project",
-    description: "Experimenteel project waarin AI gebruikt wordt voor het genereren van metaforische verhalen, baśnie en fictieve analyses. Geen echte bedrijfsactiviteit.",
+    title: "Daremon – Persoonlijk Digitaal Laboratorium",
+    description: "Experimenteel AI-project voor het ordenen van gedachten en genereren van metaforische verhalen.",
   },
 };
 
@@ -26,38 +26,17 @@ export default function RootLayout({
         <Navigation />
         <main>{children}</main>
 
-        {/* Central Site Disclaimer */}
-        <section className="site-disclaimer border-t border-cyan-500/30 bg-slate-900/50 mt-20 py-12">
-          <div className="container mx-auto px-4 max-w-4xl">
-            <h2 className="text-2xl font-bold text-cyan-400 mb-4">Oświadczenie / Verklaring</h2>
-            <div className="space-y-4 text-slate-300">
-              <p>
-                Deze website is een <strong>experimenteel narratief project</strong>. Het merendeel van de inhoud is
-                gegenereerd door kunstmatige intelligentie (AI) op basis van gesprekken en notities van de gebruiker.
-              </p>
-              <p>
-                De materialen hebben een <strong>fictief, metaforisch en experimenteel karakter</strong>. Ze weerspiegelen
-                geen echte bedrijfsactiviteiten en zijn geen plan voor het oprichten van een bedrijf. Beschouw ze als
-                verhalen, sprookjes en analyses die zijn gemaakt als onderdeel van een proces om gedachten te ordenen.
-              </p>
-              <p className="text-sm italic text-slate-400">
-                Ta strona jest eksperymentem narracyjnym. Większość treści została wygenerowana przez systemy sztucznej
-                inteligencji. Materiały mają charakter fikcyjny, metaforyczny i testowy – nie odzwierciedlają rzeczywistej
-                działalności gospodarczej ani planu założenia firmy.
-              </p>
-            </div>
-          </div>
-        </section>
-
         <footer className="border-t border-slate-800 bg-slate-950">
           <div className="container mx-auto px-4 py-8">
-            <p className="text-center text-slate-400 text-sm mb-2">
-              © {new Date().getFullYear()} Daremon – Experimenteel AI Narratief Project
-            </p>
-            <p className="text-center text-slate-500 text-xs">
-              Elke overeenkomst met echte personen, bedrijven of situaties is toevallig of metaforisch.
-              Deze site documenteert geen bedrijfsactiviteiten.
-            </p>
+            <div className="max-w-4xl mx-auto text-center space-y-3">
+              <p className="text-slate-400 text-sm">
+                © {new Date().getFullYear()} Daremon – persoonlijk digitaal laboratorium
+              </p>
+              <p className="text-slate-500 text-xs">
+                Deze website documenteert persoonlijke experimenten en technische analyses.
+                Geen commerciële activiteit. <a href="/legal" className="underline hover:text-slate-400 transition">Meer informatie</a>
+              </p>
+            </div>
           </div>
         </footer>
       </body>

--- a/app/legal/page.tsx
+++ b/app/legal/page.tsx
@@ -1,0 +1,211 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Legal & Disclaimer – Daremon',
+  description: 'Juridische informatie en disclaimer over het Daremon AI-experiment.',
+}
+
+export default function LegalPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950">
+      <div className="max-w-4xl mx-auto px-4 py-12">
+        <div className="text-center space-y-4 mb-16">
+          <h1 className="text-4xl md:text-5xl font-bold text-slate-100">Legal & Disclaimer</h1>
+          <p className="text-xl text-cyan-400 font-light">
+            Juridische informatie over dit experimentele AI-project
+          </p>
+        </div>
+
+        {/* Juridische Status */}
+        <section className="mb-12">
+          <div className="backdrop-blur-sm bg-slate-900/50 border border-cyan-500/30 rounded-lg p-8 shadow-[0_0_15px_rgba(0,255,255,0.2)]">
+            <h2 className="text-2xl font-bold text-slate-100 mb-6 border-b border-cyan-500/30 pb-4">
+              Juridische Status
+            </h2>
+            <div className="space-y-4 text-slate-300 leading-relaxed">
+              <p>
+                Daremon is een <strong>persoonlijk experimenteel project</strong> en geen geregistreerde
+                onderneming, handelsnaam of bedrijfsactiviteit.
+              </p>
+              <p>
+                Er zijn geen commerciële diensten, geen zakelijke activiteiten en geen aanbod van
+                professionele dienstverlening. Dit project valt niet onder artikel 11 van het
+                Nederlandse handelsrecht dat betrekking heeft op commerciële activiteiten.
+              </p>
+              <p>
+                De eigenaar van dit project verricht geen beroepsmatige of bedrijfsmatige handelingen
+                via deze website en heeft geen intentie een bedrijf te starten.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Aard van de Content */}
+        <section className="mb-12">
+          <div className="backdrop-blur-sm bg-slate-900/50 border border-cyan-500/30 rounded-lg p-8 shadow-[0_0_15px_rgba(0,255,255,0.2)]">
+            <h2 className="text-2xl font-bold text-slate-100 mb-6 border-b border-cyan-500/30 pb-4">
+              Aard van de Content
+            </h2>
+            <div className="space-y-4 text-slate-300 leading-relaxed">
+              <p>
+                Het grootste deel van de content op deze website is gegenereerd door kunstmatige
+                intelligentie (AI-systemen) op basis van persoonlijke gesprekken, notities en gedachten.
+              </p>
+              <p>
+                Alle materialen hebben een <strong>fictief, metaforisch en experimenteel karakter</strong>:
+              </p>
+              <ul className="list-disc list-inside space-y-2 ml-4">
+                <li>
+                  Beschrijvingen van "diensten" zijn hypothetische scenario's, geen aanbod van werkelijke
+                  diensten
+                </li>
+                <li>
+                  "Casussen" en "projecten" zijn fictieve verhalen (baśnie/fabels), geen documentatie van
+                  echte opdrachten
+                </li>
+                <li>
+                  "Analyses" en "rapporten" zijn AI-gegenereerde teksten zonder claim op professionele
+                  expertise
+                </li>
+                <li>
+                  Technische beschrijvingen zijn gebaseerd op persoonlijke ervaringen en AI-patronen, niet
+                  op gecertificeerde kennis
+                </li>
+              </ul>
+              <p>
+                De website dient als een <strong>digitaal laboratorium</strong> voor het ordenen van
+                gedachten, experimenteren met AI en creëren van metaforische verhalen.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Geen Zakelijke Relatie */}
+        <section className="mb-12">
+          <div className="backdrop-blur-sm bg-slate-900/50 border border-cyan-500/30 rounded-lg p-8 shadow-[0_0_15px_rgba(0,255,255,0.2)]">
+            <h2 className="text-2xl font-bold text-slate-100 mb-6 border-b border-cyan-500/30 pb-4">
+              Geen Zakelijke Relatie
+            </h2>
+            <div className="space-y-4 text-slate-300 leading-relaxed">
+              <p>
+                Door het bezoeken van deze website, het lezen van de content of het opnemen van contact
+                ontstaat <strong>geen enkele zakelijke relatie, contractuele verplichting of
+                dienstverleningsovereenkomst</strong>.
+              </p>
+              <p>
+                Er kunnen geen diensten worden afgenomen, geen offertes worden aangevraagd en geen
+                opdrachten worden gegeven. Contact is uitsluitend mogelijk voor informele gesprekken over
+                het project zelf.
+              </p>
+              <p>
+                Elk gebruik van of verwijzing naar deze website mag niet worden geïnterpreteerd als een
+                commerciële intentie of zakelijk aanbod.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Aansprakelijkheid */}
+        <section className="mb-12">
+          <div className="backdrop-blur-sm bg-slate-900/50 border border-cyan-500/30 rounded-lg p-8 shadow-[0_0_15px_rgba(0,255,255,0.2)]">
+            <h2 className="text-2xl font-bold text-slate-100 mb-6 border-b border-cyan-500/30 pb-4">
+              Aansprakelijkheid
+            </h2>
+            <div className="space-y-4 text-slate-300 leading-relaxed">
+              <p>
+                De eigenaar van deze website aanvaardt geen aansprakelijkheid voor:
+              </p>
+              <ul className="list-disc list-inside space-y-2 ml-4">
+                <li>Juistheid, volledigheid of actualiteit van de gepubliceerde informatie</li>
+                <li>Beslissingen genomen op basis van de content op deze website</li>
+                <li>Schade of verlies voortvloeiend uit het gebruik van deze website</li>
+                <li>Interpretatie van fictieve content als feitelijke informatie of professioneel advies</li>
+              </ul>
+              <p>
+                Alle informatie wordt verstrekt "as is" zonder enige garantie of claim op correctheid.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Intellectueel Eigendom */}
+        <section className="mb-12">
+          <div className="backdrop-blur-sm bg-slate-900/50 border border-cyan-500/30 rounded-lg p-8 shadow-[0_0_15px_rgba(0,255,255,0.2)]">
+            <h2 className="text-2xl font-bold text-slate-100 mb-6 border-b border-cyan-500/30 pb-4">
+              Intellectueel Eigendom
+            </h2>
+            <div className="space-y-4 text-slate-300 leading-relaxed">
+              <p>
+                De content op deze website is een combinatie van:
+              </p>
+              <ul className="list-disc list-inside space-y-2 ml-4">
+                <li>Persoonlijke gedachten en notities van de eigenaar</li>
+                <li>AI-gegenereerde teksten op basis van bovenstaande input</li>
+                <li>Openbare technische documentatie (waar van toepassing)</li>
+              </ul>
+              <p>
+                Het gebruik van AI-gegenereerde content brengt specifieke overwegingen met zich mee
+                omtrent auteursrecht. De eigenaar maakt geen claims op exclusief eigendom van
+                AI-gegenereerde teksten, maar behoudt zich het recht voor om de content te gebruiken,
+                aanpassen en verwijderen naar eigen inzicht.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Privacy */}
+        <section className="mb-12">
+          <div className="backdrop-blur-sm bg-slate-900/50 border border-cyan-500/30 rounded-lg p-8 shadow-[0_0_15px_rgba(0,255,255,0.2)]">
+            <h2 className="text-2xl font-bold text-slate-100 mb-6 border-b border-cyan-500/30 pb-4">
+              Privacy
+            </h2>
+            <div className="space-y-4 text-slate-300 leading-relaxed">
+              <p>
+                Deze website verzamelt geen persoonlijke gegevens via tracking, cookies of analytics,
+                tenzij uitdrukkelijk vermeld bij specifieke functies (zoals het contactformulier).
+              </p>
+              <p>
+                Eventuele communicatie via e-mail wordt vertrouwelijk behandeld en niet gedeeld met
+                derden. Er is geen commerciële verwerking van persoonsgegevens.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Contact */}
+        <section className="mb-12">
+          <div className="backdrop-blur-sm bg-slate-900/50 border border-cyan-500/30 rounded-lg p-8 shadow-[0_0_15px_rgba(0,255,255,0.2)]">
+            <h2 className="text-2xl font-bold text-slate-100 mb-6 border-b border-cyan-500/30 pb-4">
+              Contact & Vragen
+            </h2>
+            <div className="space-y-4 text-slate-300 leading-relaxed">
+              <p>
+                Voor vragen over deze disclaimer of het project in het algemeen:
+              </p>
+              <p>
+                <strong className="text-cyan-400">E-mail:</strong> info@daremon.nl
+              </p>
+              <p className="text-sm text-slate-400">
+                Let op: Dit is geen zakelijk contactadres. Vragen met commerciële intenties kunnen
+                niet beantwoord worden.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Laatste Update */}
+        <section className="mb-12">
+          <div className="text-center text-sm text-slate-500">
+            <p>Laatste update: December 2025</p>
+            <p className="mt-2">
+              <Link href="/" className="text-cyan-400 hover:underline transition">
+                ← Terug naar home
+              </Link>
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/app/over/page.tsx
+++ b/app/over/page.tsx
@@ -17,31 +17,6 @@ export default function OverPage() {
           </p>
         </div>
 
-        {/* Disclaimer */}
-        <section className="mb-16">
-          <div className="backdrop-blur-sm bg-red-950/30 border border-red-500/50 rounded-lg p-8 shadow-[0_0_15px_rgba(255,0,0,0.2)]">
-            <h2 className="text-2xl font-bold text-red-300 mb-4 flex items-center gap-3">
-              <span className="text-3xl">⚠</span>
-              Belangrijke waarschuwing
-            </h2>
-            <div className="space-y-3 text-slate-200 leading-relaxed">
-              <p className="font-semibold">
-                Daremon is <strong className="text-red-300">geen bedrijf</strong> en <strong className="text-red-300">geen plan om een bedrijf te starten</strong>.
-              </p>
-              <p>
-                Deze website en alle inhoud zijn een <strong>experimenteel narratief project</strong> waarin
-                kunstmatige intelligentie (AI) wordt gebruikt om fictieve verhalen, metaforische scenario's
-                en hypothetische analyses te genereren.
-              </p>
-              <p className="text-sm">
-                Alle beschrijvingen van "diensten", "casussen", "klanten" en "projecten" zijn
-                <strong> fictief</strong> of <strong>metaforisch</strong>. Ze vormen geen aanbod, geen
-                commerciële activiteit en geen bewijs van zakelijke plannen.
-              </p>
-            </div>
-          </div>
-        </section>
-
         {/* Wat is dit eigenlijk? */}
         <section className="mb-16">
           <div className="backdrop-blur-sm bg-slate-900/50 border border-cyan-500/30 rounded-lg p-8 shadow-[0_0_15px_rgba(0,255,255,0.2)]">
@@ -112,18 +87,6 @@ export default function OverPage() {
                   corresponderen met concrete plannen of acties.
                 </p>
               </div>
-
-              <div>
-                <h3 className="text-xl font-semibold text-slate-100 mb-3 flex items-start gap-3">
-                  <span className="text-cyan-400 flex-shrink-0">▸</span>
-                  Geen echte expertise
-                </h3>
-                <p className="text-slate-300 leading-relaxed">
-                  Hoewel de AI-gegenereerde teksten soms klinken alsof ze van een expert komen, zijn
-                  het fictieve constructies. Ze zijn gebaseerd op patronen in de trainingsdata van de
-                  AI, niet op daadwerkelijke professionele ervaring of gecertificeerde expertise.
-                </p>
-              </div>
             </div>
           </div>
         </section>
@@ -148,20 +111,6 @@ export default function OverPage() {
                   <li>Exploratieve analyses zonder praktische toepassing</li>
                 </ul>
               </div>
-              <div className="bg-red-950/20 border border-red-800/50 rounded-lg p-4 my-4">
-                <p className="text-red-300 font-semibold mb-2">Interpreteer de inhoud NIET als:</p>
-                <ul className="list-disc list-inside space-y-1 text-slate-300">
-                  <li>Een aanbod van commerciële diensten</li>
-                  <li>Bewijs van zakelijke activiteiten of plannen</li>
-                  <li>Professionele expertise of advies</li>
-                  <li>Documentatie van echte projecten of klanten</li>
-                  <li>Een poging om klanten of opdrachten te werven</li>
-                </ul>
-              </div>
-              <p>
-                Als je iets interessants vindt in de teksten, is dat prima – maar besef dat het
-                <strong> geen basis vormt voor zakelijke verwachtingen of contractuele afspraken</strong>.
-              </p>
             </div>
           </div>
         </section>
@@ -180,7 +129,6 @@ export default function OverPage() {
               <p>
                 Deze naam past bij de metaforische verhalen die hier worden gegenereerd – verhalen over
                 onderliggende processen, verborgen structuren en systemen die op de achtergrond draaien.
-                Maar het is een <strong>literaire keuze</strong>, geen zakelijke naam.
               </p>
             </div>
           </div>
@@ -192,7 +140,7 @@ export default function OverPage() {
             <h2 className="text-2xl font-bold text-slate-100 mb-4">Vragen over dit project?</h2>
             <p className="text-slate-300 mb-6">
               Als je nieuwsgierig bent naar dit experiment of gewoon wilt praten over ideeën,
-              kun je contact opnemen. Maar verwacht geen zakelijke voorstellen of offertes.
+              kun je contact opnemen.
             </p>
             <Link
               href="/contact"


### PR DESCRIPTION
- Removed all large red/amber warning banners from main pages
- Consolidated disclaimers into single calm footer message
- Created new /legal page for comprehensive legal information
- Rewrote FAQ from defensive "No, no, no..." to positive tone
- Removed repetitive warnings across all pages
- Changed tone from "please don't sue me" to "personal digital lab"

Key changes:
- app/layout.tsx: Removed 22-line disclaimer section, new minimal footer
- app/home/page.tsx: Removed red banner and 3 defensive texts
- app/over/page.tsx: Removed red disclaimer and 4 defensive texts
- app/diensten/page.tsx: Removed amber banner and 4 repetitions
- app/casussen/page.tsx: Removed both disclaimers
- app/contact/page.tsx: Removed amber banner, rewrote FAQ (5→3 questions)
- app/legal/page.tsx: Created new comprehensive legal page
- README.md: Changed defensive tone to neutral

Result: ~87% reduction in disclaimer text, professional calm tone